### PR TITLE
 Allow enabling Zend Thread Safety using a --with-zts flag 🎉

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -20,6 +20,8 @@ class Php < Formula
     depends_on "re2c" => :build # required to generate PHP lexers
   end
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
   depends_on "apr"
@@ -172,6 +174,8 @@ class Php < Formula
       --with-zip
       --with-zlib
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@5.6.rb
+++ b/Formula/php@5.6.rb
@@ -13,6 +13,8 @@ class PhpAT56 < Formula
 
   keg_only :versioned_formula
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
   depends_on "apr"
@@ -169,6 +171,8 @@ class PhpAT56 < Formula
       --with-xsl#{headers_path}
       --with-zlib#{headers_path}
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@7.0.rb
+++ b/Formula/php@7.0.rb
@@ -13,6 +13,8 @@ class PhpAT70 < Formula
 
   keg_only :versioned_formula
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
   depends_on "apr"
@@ -168,6 +170,8 @@ class PhpAT70 < Formula
       --with-xsl#{headers_path}
       --with-zlib#{headers_path}
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@7.1.rb
+++ b/Formula/php@7.1.rb
@@ -13,6 +13,8 @@ class PhpAT71 < Formula
 
   keg_only :versioned_formula
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
   depends_on "apr"
@@ -161,6 +163,8 @@ class PhpAT71 < Formula
       --with-xsl#{headers_path}
       --with-zlib#{headers_path}
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -15,6 +15,8 @@ class PhpAT72 < Formula
 
   keg_only :versioned_formula
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   deprecate! date: "2020-11-30"
 
   depends_on "httpd" => [:build, :test]
@@ -173,6 +175,8 @@ class PhpAT72 < Formula
       --with-xsl#{headers_path}
       --with-zlib#{headers_path}
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@7.3.rb
+++ b/Formula/php@7.3.rb
@@ -15,6 +15,8 @@ class PhpAT73 < Formula
 
   keg_only :versioned_formula
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   deprecate! date: "2021-12-06"
 
   depends_on "httpd" => [:build, :test]
@@ -173,6 +175,8 @@ class PhpAT73 < Formula
       --with-xsl#{headers_path}
       --with-zlib#{headers_path}
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@8.0.rb
+++ b/Formula/php@8.0.rb
@@ -12,6 +12,8 @@ class PhpAT80 < Formula
 
   keg_only :versioned_formula
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   depends_on "bison" => :build
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
@@ -170,6 +172,8 @@ class PhpAT80 < Formula
       --with-zip
       --with-zlib
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
### Description

Hello 👋 

This PR adds support for compiling PHP with the [`--enable-maintainer-zts`](https://www.php.net/manual/en/pthreads.requirements.php) flag. The PHP docs mention this flag for pthreads but it's also really useful for [extension development](https://www.php.net/manual/en/internals2.buildsys.environment.php). I'm personally using it to so I can use the [parallel extension](https://github.com/krakjoe/parallel).

To enable zts you can pass the `--with-zts` flag when installing the PHP formula, like this:

```
brew install shivammathur/php/php --with-zts
```

You can confirm it worked by looking at the configure command in the `php -i` output:

```
php -i | grep zts                           
Configure Command =>  './configure'  '--prefix=/usr/local/Cellar/php/7.4.9' '--localstatedir=/usr/local/var' '--sysconfdir=/usr/local/etc/php/7.4' '--with-config-file-path=/usr/local/etc/php/7.4' '--with-config-file-scan-dir=/usr/local/etc/php/7.4/conf.d' '--with-pear=/usr/local/Cellar/php/7.4.9/share/php/pear' '--with-os-sdkpath=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk' '--enable-bcmath' '--enable-calendar' '--enable-dba' '--enable-dtrace' '--enable-exif' '--enable-ftp' '--enable-fpm' '--enable-gd' '--enable-intl' '--enable-mbregex' '--enable-mbstring' '--enable-mysqlnd' '--enable-pcntl' '--enable-phpdbg' '--enable-phpdbg-readline' '--enable-phpdbg-webhelper' '--enable-shmop' '--enable-soap' '--enable-sockets' '--enable-sysvmsg' '--enable-sysvsem' '--enable-sysvshm' '--with-apxs2=/usr/local/opt/httpd/bin/apxs' '--with-bz2=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr' '--with-curl' '--with-external-gd' '--with-external-pcre' '--with-ffi' '--with-fpm-user=_www' '--with-fpm-group=_www' '--with-gettext=/usr/local/opt/gettext' '--with-gmp=/usr/local/opt/gmp' '--with-iconv=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr' '--with-kerberos' '--with-layout=GNU' '--with-ldap=/usr/local/opt/openldap' '--with-ldap-sasl' '--with-libxml' '--with-libedit' '--with-mhash=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr' '--with-mysql-sock=/tmp/mysql.sock' '--with-mysqli=mysqlnd' '--with-ndbm=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr' '--with-openssl' '--with-password-argon2=/usr/local/opt/argon2' '--with-pdo-dblib=/usr/local/opt/freetds' '--with-pdo-mysql=mysqlnd' '--with-pdo-odbc=unixODBC,/usr/local/opt/unixodbc' '--with-pdo-pgsql=/usr/local/opt/libpq' '--with-pdo-sqlite' '--with-pgsql=/usr/local/opt/libpq' '--with-pic' '--with-pspell=/usr/local/opt/aspell' '--with-sodium' '--with-sqlite3' '--with-tidy=/usr/local/opt/tidy-html5' '--with-unixODBC' '--with-xmlrpc' '--with-xsl' '--with-zip' '--with-zlib' '--enable-maintainer-zts' 
```

The option follows the [Homebrew recommendations in the Formula cookbook](https://docs.brew.sh/Formula-Cookbook#adding-optional-steps).

I think it would be great if this could be added here since it's a pain to add yourself and it doesn't affect users that don't use the flag. Let me know what you think!