### PR TITLE
Add --with-zts and --with-debug options 🎉

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -20,6 +20,8 @@ class Php < Formula
     depends_on "re2c" => :build # required to generate PHP lexers
   end
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
   depends_on "apr"
@@ -172,6 +174,8 @@ class Php < Formula
       --with-zip
       --with-zlib
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -21,6 +21,7 @@ class Php < Formula
   end
 
   option "with-zts", "Enable Zend Thread Safety"
+  option "with-debug", "Enable debug mode"
 
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
@@ -176,6 +177,7 @@ class Php < Formula
     ]
 
     args << "--enable-maintainer-zts" if build.with? "zts"
+    args << "--enable-debug" if build.with? "debug"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@5.6.rb
+++ b/Formula/php@5.6.rb
@@ -14,6 +14,7 @@ class PhpAT56 < Formula
   keg_only :versioned_formula
 
   option "with-zts", "Enable Zend Thread Safety"
+  option "with-debug", "Enable debug mode"
 
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
@@ -173,6 +174,7 @@ class PhpAT56 < Formula
     ]
 
     args << "--enable-maintainer-zts" if build.with? "zts"
+    args << "--enable-debug" if build.with? "debug"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@5.6.rb
+++ b/Formula/php@5.6.rb
@@ -13,6 +13,8 @@ class PhpAT56 < Formula
 
   keg_only :versioned_formula
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
   depends_on "apr"
@@ -169,6 +171,8 @@ class PhpAT56 < Formula
       --with-xsl#{headers_path}
       --with-zlib#{headers_path}
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@7.0.rb
+++ b/Formula/php@7.0.rb
@@ -14,6 +14,7 @@ class PhpAT70 < Formula
   keg_only :versioned_formula
 
   option "with-zts", "Enable Zend Thread Safety"
+  option "with-debug", "Enable debug mode"
 
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
@@ -172,6 +173,7 @@ class PhpAT70 < Formula
     ]
 
     args << "--enable-maintainer-zts" if build.with? "zts"
+    args << "--enable-debug" if build.with? "debug"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@7.0.rb
+++ b/Formula/php@7.0.rb
@@ -13,6 +13,8 @@ class PhpAT70 < Formula
 
   keg_only :versioned_formula
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
   depends_on "apr"
@@ -168,6 +170,8 @@ class PhpAT70 < Formula
       --with-xsl#{headers_path}
       --with-zlib#{headers_path}
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@7.1.rb
+++ b/Formula/php@7.1.rb
@@ -14,6 +14,7 @@ class PhpAT71 < Formula
   keg_only :versioned_formula
 
   option "with-zts", "Enable Zend Thread Safety"
+  option "with-debug", "Enable debug mode"
 
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
@@ -165,6 +166,7 @@ class PhpAT71 < Formula
     ]
 
     args << "--enable-maintainer-zts" if build.with? "zts"
+    args << "--enable-debug" if build.with? "debug"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@7.1.rb
+++ b/Formula/php@7.1.rb
@@ -13,6 +13,8 @@ class PhpAT71 < Formula
 
   keg_only :versioned_formula
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
   depends_on "apr"
@@ -161,6 +163,8 @@ class PhpAT71 < Formula
       --with-xsl#{headers_path}
       --with-zlib#{headers_path}
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -15,6 +15,8 @@ class PhpAT72 < Formula
 
   keg_only :versioned_formula
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   deprecate! date: "2020-11-30"
 
   depends_on "httpd" => [:build, :test]
@@ -173,6 +175,8 @@ class PhpAT72 < Formula
       --with-xsl#{headers_path}
       --with-zlib#{headers_path}
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -16,6 +16,7 @@ class PhpAT72 < Formula
   keg_only :versioned_formula
 
   option "with-zts", "Enable Zend Thread Safety"
+  option "with-debug", "Enable debug mode"
 
   deprecate! date: "2020-11-30"
 
@@ -177,6 +178,7 @@ class PhpAT72 < Formula
     ]
 
     args << "--enable-maintainer-zts" if build.with? "zts"
+    args << "--enable-debug" if build.with? "debug"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@7.3.rb
+++ b/Formula/php@7.3.rb
@@ -16,6 +16,7 @@ class PhpAT73 < Formula
   keg_only :versioned_formula
 
   option "with-zts", "Enable Zend Thread Safety"
+  option "with-debug", "Enable debug mode"
 
   deprecate! date: "2021-12-06"
 
@@ -177,6 +178,7 @@ class PhpAT73 < Formula
     ]
 
     args << "--enable-maintainer-zts" if build.with? "zts"
+    args << "--enable-debug" if build.with? "debug"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@7.3.rb
+++ b/Formula/php@7.3.rb
@@ -15,6 +15,8 @@ class PhpAT73 < Formula
 
   keg_only :versioned_formula
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   deprecate! date: "2021-12-06"
 
   depends_on "httpd" => [:build, :test]
@@ -173,6 +175,8 @@ class PhpAT73 < Formula
       --with-xsl#{headers_path}
       --with-zlib#{headers_path}
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@8.0.rb
+++ b/Formula/php@8.0.rb
@@ -12,6 +12,8 @@ class PhpAT80 < Formula
 
   keg_only :versioned_formula
 
+  option "with-zts", "Enable Zend Thread Safety"
+
   depends_on "bison" => :build
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build
@@ -170,6 +172,8 @@ class PhpAT80 < Formula
       --with-zip
       --with-zlib
     ]
+
+    args << "--enable-maintainer-zts" if build.with? "zts"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@8.0.rb
+++ b/Formula/php@8.0.rb
@@ -13,6 +13,7 @@ class PhpAT80 < Formula
   keg_only :versioned_formula
 
   option "with-zts", "Enable Zend Thread Safety"
+  option "with-debug", "Enable debug mode"
 
   depends_on "bison" => :build
   depends_on "httpd" => [:build, :test]
@@ -174,6 +175,7 @@ class PhpAT80 < Formula
     ]
 
     args << "--enable-maintainer-zts" if build.with? "zts"
+    args << "--enable-debug" if build.with? "debug"
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
### Description

Hello 👋 

This PR adds support for compiling PHP with the [`--enable-maintainer-zts`](https://www.php.net/manual/en/pthreads.requirements.php) and [`--enable-debug`](https://www.php.net/manual/en/configure.about.php) flags. These flags are really useful for [extension development](https://www.php.net/manual/en/internals2.buildsys.environment.php), using the [parallel extension](https://github.com/krakjoe/parallel), and using pthreads with older PHP versions.

To enable the flags you can pass the `--with-zts` or `--with-debug` flags when installing the PHP formula, like this:

```
brew install shivammathur/php/php --with-zts --with-debug
```

You can confirm it worked by looking at the configure command in the `php -i` output:

```
php -i | grep Configure
```

The options follow the [Homebrew recommendations in the Formula cookbook](https://docs.brew.sh/Formula-Cookbook#adding-optional-steps).

I think it would be great if this could be added here since it's a pain to add yourself and it doesn't affect users that don't use the flag. I think there's a good chance that if you're testing bleeding edge PHP versions you might want to use debug mode too. Let me know what you think!