### PR TITLE
🐞 Bug Fix: Remove argon2 path from 8.1 config flag

### DIFF
--- a/Formula/php@8.1.rb
+++ b/Formula/php@8.1.rb
@@ -168,7 +168,7 @@ class PhpAT81 < Formula
       --with-mysqli=mysqlnd
       --with-ndbm#{headers_path}
       --with-openssl
-      --with-password-argon2=#{Formula["argon2"].opt_prefix}
+      --with-password-argon2
       --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
       --with-pdo-mysql=mysqlnd
       --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}


### PR DESCRIPTION
Related issue: https://github.com/php/php-src/pull/7538

### Description

In PHP 8.1 argon2 lib is found using pkg-config/pkgconfig - because of this the flag no longer needs (or uses) any input values.
Having it included shouldn't hurt anything, but it also doesn't provide any affect when building PHP.

---

Additionally, the current HEAD for PHP 8.1 has a bug, but the fix for that bug is here: https://github.com/php/php-src/pull/7538
Once that merges in libargon2 should work fine again - though as this is technically a related but not-dependent change that's why I'm proposing this before that is merged in.