### PR TITLE
Add PHP formulae with debug symbols enabled

### DIFF
--- a/.github/scripts/edit.sh
+++ b/.github/scripts/edit.sh
@@ -30,7 +30,7 @@ check_changes() {
 fetch() {
   sudo cp "Formula/$PHP_VERSION.rb" "/tmp/$PHP_VERSION.rb"
   if [[ "$PHP_VERSION" =~ php@(5.6|7.[0-3]) ]]; then
-    commit=$(git ls-remote https://github.com/shivammathur/php-src-backports | grep "refs/tags/${PHP_VERSION/php@}.*{}" | sed "s/\s*refs.*//")
+    commit=$(git ls-remote https://github.com/shivammathur/php-src-backports | grep "refs/tags/$(echo "$PHP_VERSION" | grep -Eo "[0-9]+.[0-9]+").*{}" | sed "s/\s*refs.*//")
     sed -i -e "s|archive.*|archive/$commit.tar.gz\"|g" ./Formula/"$PHP_VERSION".rb
     url="$(grep -e "^  url.*" ./Formula/"$PHP_VERSION".rb | cut -d\" -f 2)"
     checksum=$(curl -sSL "$url" | shasum -a 256 | cut -d' ' -f 1)
@@ -48,7 +48,8 @@ fetch() {
     fi
   elif [[ "$PHP_VERSION" =~ php@8.[2-9] ]]; then
     master_version=$(curl -sL https://raw.githubusercontent.com/php/php-src/master/main/php_version.h | grep -Po 'PHP_VERSION "\K[0-9]+\.[0-9]+')
-    [ "${PHP_VERSION##*@}" = "$master_version" ] && branch=master || branch=PHP-"${PHP_VERSION##*@}"
+    PHP_MM=$(echo "$PHP_VERSION" | grep -Eo "[0-9]+.[0-9]+")
+    [ "$PHP_MM" = "$master_version" ] && branch=master || branch=PHP-"$PHP_MM"
     commit="$(curl -sL https://api.github.com/repos/php/php-src/commits/"$branch" | sed -n 's|^  "sha":.*"\([a-f0-9]*\)",|\1|p')"
     url="https://github.com/php/php-src/archive/$commit.tar.gz?commit=$commit"
     checksum=$(curl -sSL "$url" | shasum -a 256 | cut -d' ' -f 1)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
           - 'php@7.4'
           - 'php@8.0'
           - 'php@8.2'
+          - 'php-debug'
           - 'php@5.6-debug'
           - 'php@7.0-debug'
           - 'php@7.1-debug'
@@ -86,7 +87,6 @@ jobs:
           - 'php@7.3-debug'
           - 'php@7.4-debug'
           - 'php@8.0-debug'
-          - 'php@8.1-debug'
           - 'php@8.2-debug'
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,15 @@ jobs:
           - 'php@7.4'
           - 'php@8.0'
           - 'php@8.2'
+          - 'php@5.6-debug'
+          - 'php@7.0-debug'
+          - 'php@7.1-debug'
+          - 'php@7.2-debug'
+          - 'php@7.3-debug'
+          - 'php@7.4-debug'
+          - 'php@8.0-debug'
+          - 'php@8.1-debug'
+          - 'php@8.2-debug'
     steps:
       - uses: actions/checkout@v3
 

--- a/Aliases/php@8.1-debug
+++ b/Aliases/php@8.1-debug
@@ -1,0 +1,1 @@
+../Formula/php-debug.rb

--- a/Formula/php-debug.rb
+++ b/Formula/php-debug.rb
@@ -1,4 +1,4 @@
-class PhpAT81Debug < Formula
+class PhpDebug < Formula
   desc "General-purpose scripting language"
   homepage "https://www.php.net/"
   # Should only be updated if the new version is announced on the homepage, https://www.php.net/

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -23,7 +23,7 @@ class Php < Formula
   end
 
   head do
-    url "https://github.com/php/php-src.git"
+    url "https://github.com/php/php-src.git", branch: "master"
 
     depends_on "bison" => :build # bison >= 3.0.0 required to generate parsers
     depends_on "re2c" => :build # required to generate PHP lexers

--- a/Formula/php@5.6-debug.rb
+++ b/Formula/php@5.6-debug.rb
@@ -1,0 +1,549 @@
+class PhpAT56Debug < Formula
+  desc "General-purpose scripting language"
+  homepage "https://secure.php.net/"
+  url "https://github.com/shivammathur/php-src-backports/archive/ebb82d7337885ac0d4346a943e336e9784d3af55.tar.gz"
+  version "5.6.40"
+  sha256 "9d556c089a7cde5341744691920b482dc90013a8420973822235a5758502f797"
+  license "PHP-3.01"
+  revision 4
+
+  bottle do
+    root_url "https://ghcr.io/v2/shivammathur/php"
+    rebuild 5
+    sha256 arm64_monterey: "82f548c3bf4bd359ff54edd8318b15cf35a5b9a561afac93b27280c9537ed6dc"
+    sha256 arm64_big_sur:  "5fd5cd7a4636ba3d5a0f2c98efa10898fdac45504b82876796023faa75532508"
+    sha256 monterey:       "cff6fe8c322e9725ee3884907273e046addaffc8143de4f0cbf826f611812d30"
+    sha256 big_sur:        "9f18326a806033cc946b4d663fc074366f8c71953fd1be4ee85edcf910e1a1b1"
+    sha256 catalina:       "eec921dcafdba1a8836f6f1551a701980a6bc010f4b70ff17c86b4c3172c4411"
+    sha256 x86_64_linux:   "2a77db2eea5fade5301b50d2c40df326de842072e5805345aa09ec739b883abe"
+  end
+
+  keg_only :versioned_formula
+
+  # This PHP version is not supported upstream as of 2018-12-31.
+  # Although, this was built with back-ported security patches,
+  # we recommended to use a currently supported PHP version.
+  # For more details, refer to https://www.php.net/eol.php
+  deprecate! date: "2018-12-31", because: :deprecated_upstream
+
+  depends_on "bison" => :build
+  depends_on "httpd" => [:build, :test]
+  depends_on "pkg-config" => :build
+  depends_on "re2c" => :build
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "aspell"
+  depends_on "autoconf"
+  depends_on "curl"
+  depends_on "freetds"
+  depends_on "freetype"
+  depends_on "gettext"
+  depends_on "gmp"
+  depends_on "icu4c"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libpq"
+  depends_on "libtool"
+  depends_on "libzip"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "pcre"
+  depends_on "sqlite"
+  depends_on "tidy-html5"
+  depends_on "unixodbc"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "libedit"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
+
+  on_macos do
+    # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/pull/3472
+    patch :DATA
+  end
+
+  def install
+    # Work around configure issues with Xcode 12
+    # See https://bugs.php.net/bug.php?id=80171
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
+    # Workaround for https://bugs.php.net/80310
+    ENV.append "CFLAGS", "-DU_DEFINE_FALSE_AND_TRUE=1"
+    ENV.append "CXXFLAGS", "-DU_DEFINE_FALSE_AND_TRUE=1"
+
+    # buildconf required due to system library linking bug patch
+    system "./buildconf", "--force"
+
+    inreplace "configure" do |s|
+      s.gsub! "APACHE_THREADED_MPM=`$APXS_HTTPD -V | grep 'threaded:.*yes'`",
+              "APACHE_THREADED_MPM="
+      s.gsub! "APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`",
+              "APXS_LIBEXECDIR='$(INSTALL_ROOT)#{lib}/httpd/modules'"
+      s.gsub! "-z `$APXS -q SYSCONFDIR`",
+              "-z ''"
+      # apxs will interpolate the @ in the versioned prefix: https://bz.apache.org/bugzilla/show_bug.cgi?id=61944
+      s.gsub! "LIBEXECDIR='$APXS_LIBEXECDIR'",
+              "LIBEXECDIR='" + "#{lib}/httpd/modules".gsub("@", "\\@") + "'"
+    end
+
+    # Update error message in apache sapi to better explain the requirements
+    # of using Apache http in combination with php if the non-compatible MPM
+    # has been selected. Homebrew has chosen not to support being able to
+    # compile a thread safe version of PHP and therefore it is not
+    # possible to recompile as suggested in the original message
+    inreplace "sapi/apache2handler/sapi_apache2.c",
+              "You need to recompile PHP.",
+              "Homebrew PHP does not support a thread-safe php binary. " \
+              "To use the PHP apache sapi please change " \
+              "your httpd config to use the prefork MPM"
+
+    inreplace "sapi/fpm/php-fpm.conf.in", ";daemonize = yes", "daemonize = no"
+
+    # API compatibility with tidy-html5 v5.0.0 - https://github.com/htacg/tidy-html5/issues/224
+    inreplace "ext/tidy/tidy.c", "buffio.h", "tidybuffio.h"
+
+    # Required due to icu4c dependency
+    ENV.cxx11
+
+    # icu4c 61.1 compatability
+    ENV.append "CPPFLAGS", "-DU_USING_ICU_NAMESPACE=1"
+
+    config_path = etc/"php/#{php_version}"
+    # Prevent system pear config from inhibiting pear install
+    (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?
+
+    # Prevent homebrew from harcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    # Each extension that is built on Mojave needs a direct reference to the
+    # sdk path or it won't find the headers
+    headers_path = ""
+    headers_path = "=#{MacOS.sdk_path_if_needed}/usr" if OS.mac?
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --with-pear=#{pkgshare}/pear
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-debug
+      --enable-exif
+      --enable-ftp
+      --enable-fpm
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-opcache
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --enable-wddx
+      --enable-zip
+      --with-apxs2=#{Formula["httpd"].opt_bin}/apxs
+      --with-curl=#{Formula["curl"].opt_prefix}
+      --with-fpm-user=_www
+      --with-fpm-group=_www
+      --with-freetype-dir=#{Formula["freetype"].opt_prefix}
+      --with-gd
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-iconv#{headers_path}
+      --with-icu-dir=#{Formula["icu4c"].opt_prefix}
+      --with-jpeg-dir=#{Formula["jpeg"].opt_prefix}
+      --with-kerberos#{headers_path}
+      --with-layout=GNU
+      --with-ldap=#{Formula["openldap"].opt_prefix}
+      --with-ldap-sasl#{headers_path}
+      --with-libzip
+      --with-mhash#{headers_path}
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-mysql=mysqlnd
+      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pdo-sqlite=#{Formula["sqlite"].opt_prefix}
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-png-dir=#{Formula["libpng"].opt_prefix}
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sqlite3=#{Formula["sqlite"].opt_prefix}
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
+      --with-unixODBC=#{Formula["unixodbc"].opt_prefix}
+      --with-xmlrpc
+    ]
+
+    if OS.mac?
+      args << "--with-bz2#{headers_path}"
+      args << "--with-libedit#{headers_path}"
+      args << "--with-libxml-dir#{headers_path}"
+      args << "--with-ndbm#{headers_path}"
+      args << "--with-xsl#{headers_path}"
+      args << "--with-zlib#{headers_path}"
+    end
+
+    if OS.linux?
+      args << "--with-zlib=#{Formula["zlib"].opt_prefix}"
+      args << "--with-bzip2=#{Formula["bzip2"].opt_prefix}"
+      args << "--with-libedit=#{Formula["libedit"].opt_prefix}"
+      args << "--with-libxml-dir=#{Formula["libxml2"].opt_prefix}"
+      args << "--with-xsl=#{Formula["libxslt"].opt_prefix}"
+      args << "--without-ldap-sasl"
+      args << "--without-ndbm"
+      args << "--without-gdbm"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", %r{; ?extension_dir = "\./"},
+        "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+    end
+
+    # Use OpenSSL cert bundle
+    openssl = Formula["openssl@1.1"]
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", /; ?openssl\.cafile=/,
+        "openssl.cafile = \"#{openssl.pkgetc}/cert.pem\""
+      inreplace "php.ini-#{mode}", /; ?openssl\.capath=/,
+        "openssl.capath = \"#{openssl.pkgetc}/certs\""
+    end
+
+    config_files = {
+      "php.ini-development"   => "php.ini",
+      "php.ini-production"    => "php.ini-production",
+      "sapi/fpm/php-fpm.conf" => "php-fpm.conf",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+
+    unless (var/"log/php-fpm.log").exist?
+      (var/"log").mkpath
+      touch var/"log/php-fpm.log"
+    end
+  end
+
+  def post_install
+    pear_prefix = pkgshare/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    pecl_path.mkpath
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear@#{php_version}"
+    cp_r pkgshare/"pear/.", pear_path
+    {
+      "php_ini"  => etc/"php/#{php_version}/php.ini",
+      "php_dir"  => pear_path,
+      "doc_dir"  => pear_path/"doc",
+      "ext_dir"  => pecl_path/php_basename,
+      "bin_dir"  => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir"  => pear_path/"cfg",
+      "www_dir"  => pear_path/"htdocs",
+      "man_dir"  => HOMEBREW_PREFIX/"share/man",
+      "test_dir" => pear_path/"test",
+      "php_bin"  => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if /(?<!bin|man)_dir$/.match?(key)
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    system bin/"pear", "update-channels"
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{php_version}/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def caveats
+    <<~EOS
+      To enable PHP in Apache add the following to httpd.conf and restart Apache:
+          LoadModule php5_module #{opt_lib}/httpd/modules/libphp5.so
+
+          <FilesMatch \\.php$>
+              SetHandler application/x-httpd-php
+          </FilesMatch>
+
+      Finally, check DirectoryIndex includes index.php
+          DirectoryIndex index.php index.html
+
+      The php.ini and php-fpm.ini file can be found in:
+          #{etc}/php/#{php_version}/
+    EOS
+  end
+
+  def php_version
+    version.to_s.split(".")[0..1].join(".") + "-debug"
+  end
+
+  plist_options manual: "php-fpm"
+  service do
+    run [opt_sbin/"php-fpm", "--nodaemonize"]
+    run_type :immediate
+    keep_alive true
+    error_log_path var/"log/php-fpm.log"
+    working_dir var
+  end
+
+  test do
+    assert_match(/^Zend OPcache$/, shell_output("#{bin}/php -i"),
+      "Zend OPCache extension not loaded")
+    # Test related to libxml2 and
+    # https://github.com/Homebrew/homebrew-core/issues/28398
+    if OS.mac?
+      assert_includes MachO::Tools.dylibs("#{bin}/php"),
+              "#{Formula["libpq"].opt_lib}/libpq.5.dylib"
+    end
+
+    system "#{sbin}/php-fpm", "-t"
+    system "#{bin}/phpdbg", "-V"
+    system "#{bin}/php-cgi", "-m"
+    # Prevent SNMP extension to be added
+    refute_match(/^snmp$/, shell_output("#{bin}/php -m"),
+      "SNMP extension doesn't work reliably with Homebrew on High Sierra")
+    begin
+      require "socket"
+
+      server = TCPServer.new(0)
+      port = server.addr[1]
+      server_fpm = TCPServer.new(0)
+      port_fpm = server_fpm.addr[1]
+      server.close
+      server_fpm.close
+
+      expected_output = /^Hello world!$/
+      (testpath/"index.php").write <<~EOS
+        <?php
+        echo 'Hello world!' . PHP_EOL;
+        var_dump(ldap_connect());
+      EOS
+      main_config = <<~EOS
+        Listen #{port}
+        ServerName localhost:#{port}
+        DocumentRoot "#{testpath}"
+        ErrorLog "#{testpath}/httpd-error.log"
+        ServerRoot "#{Formula["httpd"].opt_prefix}"
+        PidFile "#{testpath}/httpd.pid"
+        LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
+        LoadModule unixd_module lib/httpd/modules/mod_unixd.so
+        LoadModule dir_module lib/httpd/modules/mod_dir.so
+        DirectoryIndex index.php
+      EOS
+
+      (testpath/"httpd.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
+        LoadModule php5_module #{lib}/httpd/modules/libphp5.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler application/x-httpd-php
+        </FilesMatch>
+      EOS
+
+      (testpath/"fpm.conf").write <<~EOS
+        [global]
+        daemonize=no
+        [www]
+        listen = 127.0.0.1:#{port_fpm}
+        pm = dynamic
+        pm.max_children = 5
+        pm.start_servers = 2
+        pm.min_spare_servers = 1
+        pm.max_spare_servers = 3
+      EOS
+
+      (testpath/"httpd-fpm.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
+        LoadModule proxy_module lib/httpd/modules/mod_proxy.so
+        LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
+        </FilesMatch>
+      EOS
+
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+
+      fpm_pid = fork do
+        exec sbin/"php-fpm", "-y", "fpm.conf"
+      end
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd-fpm.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+    ensure
+      if pid
+        Process.kill("TERM", pid)
+        Process.wait(pid)
+      end
+      if fpm_pid
+        Process.kill("TERM", fpm_pid)
+        Process.wait(fpm_pid)
+      end
+    end
+  end
+end
+
+__END__
+diff --git a/acinclude.m4 b/acinclude.m4
+index 168c465f8d..6c087d152f 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -441,7 +441,11 @@ dnl
+ dnl Adds a path to linkpath/runpath (LDFLAGS)
+ dnl
+ AC_DEFUN([PHP_ADD_LIBPATH],[
+-  if test "$1" != "/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
++  case "$1" in
++  "/usr/$PHP_LIBDIR"|"/usr/lib"[)] ;;
++  /Library/Developer/CommandLineTools/SDKs/*/usr/lib[)] ;;
++  /Applications/Xcode*.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*/usr/lib[)] ;;
++  *[)]
+     PHP_EXPAND_PATH($1, ai_p)
+     ifelse([$2],,[
+       _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+@@ -452,8 +456,8 @@ AC_DEFUN([PHP_ADD_LIBPATH],[
+       else
+         _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+       fi
+-    ])
+-  fi
++    ]) ;;
++  esac
+ ])
+
+ dnl
+@@ -487,7 +491,11 @@ dnl add an include path.
+ dnl if before is 1, add in the beginning of INCLUDES.
+ dnl
+ AC_DEFUN([PHP_ADD_INCLUDE],[
+-  if test "$1" != "/usr/include"; then
++  case "$1" in
++  "/usr/include"[)] ;;
++  /Library/Developer/CommandLineTools/SDKs/*/usr/include[)] ;;
++  /Applications/Xcode*.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*/usr/include[)] ;;
++  *[)]
+     PHP_EXPAND_PATH($1, ai_p)
+     PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
+       if test "$2"; then
+@@ -495,8 +503,8 @@ AC_DEFUN([PHP_ADD_INCLUDE],[
+       else
+         INCLUDES="$INCLUDES -I$ai_p"
+       fi
+-    ])
+-  fi
++    ]) ;;
++  esac
+ ])
+
+ dnl internal, don't use
+@@ -2411,7 +2419,8 @@ AC_DEFUN([PHP_SETUP_ICONV], [
+     fi
+
+     if test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.a ||
+-       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.$SHLIB_SUFFIX_NAME
++       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.$SHLIB_SUFFIX_NAME ||
++       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.tbd
+     then
+       PHP_CHECK_LIBRARY($iconv_lib_name, libiconv, [
+         found_iconv=yes
+diff --git a/Zend/zend_compile.h b/Zend/zend_compile.h
+index a0955e34fe..09b4984f90 100644
+--- a/Zend/zend_compile.h
++++ b/Zend/zend_compile.h
+@@ -414,9 +414,6 @@ struct _zend_execute_data {
+
+ #define EX(element) execute_data.element
+
+-#define EX_TMP_VAR(ex, n)	   ((temp_variable*)(((char*)(ex)) + ((int)(n))))
+-#define EX_TMP_VAR_NUM(ex, n)  (EX_TMP_VAR(ex, 0) - (1 + (n)))
+-
+ #define EX_CV_NUM(ex, n)       (((zval***)(((char*)(ex))+ZEND_MM_ALIGNED_SIZE(sizeof(zend_execute_data))))+(n))
+
+
+diff --git a/Zend/zend_execute.h b/Zend/zend_execute.h
+index a7af67bc13..ae71a5c73f 100644
+--- a/Zend/zend_execute.h
++++ b/Zend/zend_execute.h
+@@ -71,6 +71,15 @@ ZEND_API int zend_eval_stringl_ex(char *str, int str_len, zval *retval_ptr, char
+ ZEND_API char * zend_verify_arg_class_kind(const zend_arg_info *cur_arg_info, ulong fetch_type, const char **class_name, zend_class_entry **pce TSRMLS_DC);
+ ZEND_API int zend_verify_arg_error(int error_type, const zend_function *zf, zend_uint arg_num, const char *need_msg, const char *need_kind, const char *given_msg, const char *given_kind TSRMLS_DC);
+
++static zend_always_inline temp_variable *EX_TMP_VAR(void *ex, int n)
++{
++	return (temp_variable *)((zend_uintptr_t)ex + n);
++}
++static inline temp_variable *EX_TMP_VAR_NUM(void *ex, int n)
++{
++	return (temp_variable *)((zend_uintptr_t)ex - (1 + n) * sizeof(temp_variable));
++}
++
+ static zend_always_inline void i_zval_ptr_dtor(zval *zval_ptr ZEND_FILE_LINE_DC TSRMLS_DC)
+ {
+	if (!Z_DELREF_P(zval_ptr)) {

--- a/Formula/php@7.0-debug.rb
+++ b/Formula/php@7.0-debug.rb
@@ -1,0 +1,520 @@
+class PhpAT70Debug < Formula
+  desc "General-purpose scripting language"
+  homepage "https://secure.php.net/"
+  url "https://github.com/shivammathur/php-src-backports/archive/7ed6a1d768f60080369d9372b500e0d1f99c57a4.tar.gz"
+  version "7.0.33"
+  sha256 "3c918b19564c25b000dbd42f1ade5c82ffb7d3e721cb97606f43cbb13ef1cdd5"
+  license "PHP-3.01"
+  revision 5
+
+  bottle do
+    root_url "https://ghcr.io/v2/shivammathur/php"
+    rebuild 5
+    sha256 arm64_monterey: "d11777fcdad0bc20ac84a3723ad1890474ae4ee5884dc80541a73102ba8504ed"
+    sha256 arm64_big_sur:  "9beb381e47c357d959d64185b49deae55ef35e6a8b4bda8381411771af158cca"
+    sha256 monterey:       "6387cd7afbcc8d4f1589f46e1aa071d89179e4e8f02946e0fc159dfb20aaf08b"
+    sha256 big_sur:        "d26988aaecbeb247ceb33796c69722bcd0a7726e5deb3868af34a24f0845d345"
+    sha256 catalina:       "98adaf5fae162d35047a41ef2d9ef6342ee79bf12696be01707e7fd765dd6ca7"
+    sha256 x86_64_linux:   "6ce829055c35ac01824b0ff006abe17d59f4d24e73989488b9cfaade24cf8523"
+  end
+
+  keg_only :versioned_formula
+
+  # This PHP version is not supported upstream as of 2019-01-10.
+  # Although, this was built with back-ported security patches,
+  # we recommended to use a currently supported PHP version.
+  # For more details, refer to https://www.php.net/eol.php
+  deprecate! date: "2019-01-10", because: :deprecated_upstream
+
+  depends_on "bison" => :build
+  depends_on "httpd" => [:build, :test]
+  depends_on "pkg-config" => :build
+  depends_on "re2c" => :build
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "aspell"
+  depends_on "autoconf"
+  depends_on "curl"
+  depends_on "freetds"
+  depends_on "freetype"
+  depends_on "gettext"
+  depends_on "gmp"
+  depends_on "icu4c"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libpq"
+  depends_on "libtool"
+  depends_on "libzip"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "pcre"
+  depends_on "sqlite"
+  depends_on "tidy-html5"
+  depends_on "unixodbc"
+  depends_on "webp"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "libedit"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
+
+  on_macos do
+    # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/pull/3472
+    patch :DATA
+  end
+
+  def install
+    # Work around configure issues with Xcode 12
+    # See https://bugs.php.net/bug.php?id=80171
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
+    # Workaround for https://bugs.php.net/80310
+    ENV.append "CFLAGS", "-DU_DEFINE_FALSE_AND_TRUE=1"
+    ENV.append "CXXFLAGS", "-DU_DEFINE_FALSE_AND_TRUE=1"
+
+    # buildconf required due to system library linking bug patch
+    system "./buildconf", "--force"
+
+    inreplace "configure" do |s|
+      s.gsub! "APACHE_THREADED_MPM=`$APXS_HTTPD -V | grep 'threaded:.*yes'`",
+              "APACHE_THREADED_MPM="
+      s.gsub! "APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`",
+              "APXS_LIBEXECDIR='$(INSTALL_ROOT)#{lib}/httpd/modules'"
+      s.gsub! "-z `$APXS -q SYSCONFDIR`",
+              "-z ''"
+      # apxs will interpolate the @ in the versioned prefix: https://bz.apache.org/bugzilla/show_bug.cgi?id=61944
+      s.gsub! "LIBEXECDIR='$APXS_LIBEXECDIR'",
+              "LIBEXECDIR='" + "#{lib}/httpd/modules".gsub("@", "\\@") + "'"
+    end
+
+    # Update error message in apache sapi to better explain the requirements
+    # of using Apache http in combination with php if the non-compatible MPM
+    # has been selected. Homebrew has chosen not to support being able to
+    # compile a thread safe version of PHP and therefore it is not
+    # possible to recompile as suggested in the original message
+    inreplace "sapi/apache2handler/sapi_apache2.c",
+              "You need to recompile PHP.",
+              "Homebrew PHP does not support a thread-safe php binary. " \
+              "To use the PHP apache sapi please change " \
+              "your httpd config to use the prefork MPM"
+
+    inreplace "sapi/fpm/php-fpm.conf.in", ";daemonize = yes", "daemonize = no"
+
+    # API compatibility with tidy-html5 v5.0.0 - https://github.com/htacg/tidy-html5/issues/224
+    inreplace "ext/tidy/tidy.c", "buffio.h", "tidybuffio.h"
+
+    # Required due to icu4c dependency
+    ENV.cxx11
+
+    # icu4c 61.1 compatability
+    ENV.append "CPPFLAGS", "-DU_USING_ICU_NAMESPACE=1"
+
+    config_path = etc/"php/#{php_version}"
+    # Prevent system pear config from inhibiting pear install
+    (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?
+
+    # Prevent homebrew from harcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    # Each extension that is built on Mojave needs a direct reference to the
+    # sdk path or it won't find the headers
+    headers_path = ""
+    headers_path = "=#{MacOS.sdk_path_if_needed}/usr" if OS.mac?
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --with-pear=#{pkgshare}/pear
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-debug
+      --enable-exif
+      --enable-ftp
+      --enable-fpm
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-opcache-file
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-phpdbg-webhelper
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --enable-wddx
+      --enable-zip
+      --with-apxs2=#{Formula["httpd"].opt_bin}/apxs
+      --with-curl=#{Formula["curl"].opt_prefix}
+      --with-fpm-user=_www
+      --with-fpm-group=_www
+      --with-freetype-dir=#{Formula["freetype"].opt_prefix}
+      --with-gd
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-iconv#{headers_path}
+      --with-icu-dir=#{Formula["icu4c"].opt_prefix}
+      --with-jpeg-dir=#{Formula["jpeg"].opt_prefix}
+      --with-kerberos#{headers_path}
+      --with-layout=GNU
+      --with-ldap=#{Formula["openldap"].opt_prefix}
+      --with-ldap-sasl#{headers_path}
+      --with-libzip
+      --with-mhash#{headers_path}
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pdo-sqlite=#{Formula["sqlite"].opt_prefix}
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-png-dir=#{Formula["libpng"].opt_prefix}
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sqlite3=#{Formula["sqlite"].opt_prefix}
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
+      --with-unixODBC=#{Formula["unixodbc"].opt_prefix}
+      --with-webp-dir=#{Formula["webp"].opt_prefix}
+      --with-xmlrpc
+    ]
+
+    if OS.mac?
+      args << "--enable-dtrace"
+      args << "--with-bz2#{headers_path}"
+      args << "--with-libedit#{headers_path}"
+      args << "--with-libxml-dir#{headers_path}"
+      args << "--with-ndbm#{headers_path}"
+      args << "--with-xsl#{headers_path}"
+      args << "--with-zlib#{headers_path}"
+    end
+
+    if OS.linux?
+      args << "--disable-dtrace"
+      args << "--with-zlib=#{Formula["zlib"].opt_prefix}"
+      args << "--with-bzip2=#{Formula["bzip2"].opt_prefix}"
+      args << "--with-libedit=#{Formula["libedit"].opt_prefix}"
+      args << "--with-libxml-dir=#{Formula["libxml2"].opt_prefix}"
+      args << "--with-xsl=#{Formula["libxslt"].opt_prefix}"
+      args << "--without-ldap-sasl"
+      args << "--without-ndbm"
+      args << "--without-gdbm"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", %r{; ?extension_dir = "\./"},
+        "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+    end
+
+    # Use OpenSSL cert bundle
+    openssl = Formula["openssl@1.1"]
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", /; ?openssl\.cafile=/,
+        "openssl.cafile = \"#{openssl.pkgetc}/cert.pem\""
+      inreplace "php.ini-#{mode}", /; ?openssl\.capath=/,
+        "openssl.capath = \"#{openssl.pkgetc}/certs\""
+    end
+
+    config_files = {
+      "php.ini-development"   => "php.ini",
+      "php.ini-production"    => "php.ini-production",
+      "sapi/fpm/php-fpm.conf" => "php-fpm.conf",
+      "sapi/fpm/www.conf"     => "php-fpm.d/www.conf",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+
+    unless (var/"log/php-fpm.log").exist?
+      (var/"log").mkpath
+      touch var/"log/php-fpm.log"
+    end
+  end
+
+  def post_install
+    pear_prefix = pkgshare/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    pecl_path.mkpath
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear@#{php_version}"
+    cp_r pkgshare/"pear/.", pear_path
+    {
+      "php_ini"  => etc/"php/#{php_version}/php.ini",
+      "php_dir"  => pear_path,
+      "doc_dir"  => pear_path/"doc",
+      "ext_dir"  => pecl_path/php_basename,
+      "bin_dir"  => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir"  => pear_path/"cfg",
+      "www_dir"  => pear_path/"htdocs",
+      "man_dir"  => HOMEBREW_PREFIX/"share/man",
+      "test_dir" => pear_path/"test",
+      "php_bin"  => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if /(?<!bin|man)_dir$/.match?(key)
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    system bin/"pear", "update-channels"
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{php_version}/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def caveats
+    <<~EOS
+      To enable PHP in Apache add the following to httpd.conf and restart Apache:
+          LoadModule php7_module #{opt_lib}/httpd/modules/libphp7.so
+
+          <FilesMatch \\.php$>
+              SetHandler application/x-httpd-php
+          </FilesMatch>
+
+      Finally, check DirectoryIndex includes index.php
+          DirectoryIndex index.php index.html
+
+      The php.ini and php-fpm.ini file can be found in:
+          #{etc}/php/#{php_version}/
+    EOS
+  end
+
+  def php_version
+    version.to_s.split(".")[0..1].join(".") + "-debug"
+  end
+
+  plist_options manual: "php-fpm"
+  service do
+    run [opt_sbin/"php-fpm", "--nodaemonize"]
+    run_type :immediate
+    keep_alive true
+    error_log_path var/"log/php-fpm.log"
+    working_dir var
+  end
+
+  test do
+    assert_match(/^Zend OPcache$/, shell_output("#{bin}/php -i"),
+      "Zend OPCache extension not loaded")
+    # Test related to libxml2 and
+    # https://github.com/Homebrew/homebrew-core/issues/28398
+    if OS.mac?
+      assert_includes MachO::Tools.dylibs("#{bin}/php"),
+              "#{Formula["libpq"].opt_lib}/libpq.5.dylib"
+    end
+
+    system "#{sbin}/php-fpm", "-t"
+    system "#{bin}/phpdbg", "-V"
+    system "#{bin}/php-cgi", "-m"
+    # Prevent SNMP extension to be added
+    refute_match(/^snmp$/, shell_output("#{bin}/php -m"),
+      "SNMP extension doesn't work reliably with Homebrew on High Sierra")
+    begin
+      require "socket"
+
+      server = TCPServer.new(0)
+      port = server.addr[1]
+      server_fpm = TCPServer.new(0)
+      port_fpm = server_fpm.addr[1]
+      server.close
+      server_fpm.close
+
+      expected_output = /^Hello world!$/
+      (testpath/"index.php").write <<~EOS
+        <?php
+        echo 'Hello world!' . PHP_EOL;
+        var_dump(ldap_connect());
+      EOS
+      main_config = <<~EOS
+        Listen #{port}
+        ServerName localhost:#{port}
+        DocumentRoot "#{testpath}"
+        ErrorLog "#{testpath}/httpd-error.log"
+        ServerRoot "#{Formula["httpd"].opt_prefix}"
+        PidFile "#{testpath}/httpd.pid"
+        LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
+        LoadModule unixd_module lib/httpd/modules/mod_unixd.so
+        LoadModule dir_module lib/httpd/modules/mod_dir.so
+        DirectoryIndex index.php
+      EOS
+
+      (testpath/"httpd.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
+        LoadModule php7_module #{lib}/httpd/modules/libphp7.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler application/x-httpd-php
+        </FilesMatch>
+      EOS
+
+      (testpath/"fpm.conf").write <<~EOS
+        [global]
+        daemonize=no
+        [www]
+        listen = 127.0.0.1:#{port_fpm}
+        pm = dynamic
+        pm.max_children = 5
+        pm.start_servers = 2
+        pm.min_spare_servers = 1
+        pm.max_spare_servers = 3
+      EOS
+
+      (testpath/"httpd-fpm.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
+        LoadModule proxy_module lib/httpd/modules/mod_proxy.so
+        LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
+        </FilesMatch>
+      EOS
+
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+
+      fpm_pid = fork do
+        exec sbin/"php-fpm", "-y", "fpm.conf"
+      end
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd-fpm.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+    ensure
+      if pid
+        Process.kill("TERM", pid)
+        Process.wait(pid)
+      end
+      if fpm_pid
+        Process.kill("TERM", fpm_pid)
+        Process.wait(fpm_pid)
+      end
+    end
+  end
+end
+
+__END__
+diff --git a/acinclude.m4 b/acinclude.m4
+index 168c465f8d..6c087d152f 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -441,7 +441,11 @@ dnl
+ dnl Adds a path to linkpath/runpath (LDFLAGS)
+ dnl
+ AC_DEFUN([PHP_ADD_LIBPATH],[
+-  if test "$1" != "/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
++  case "$1" in
++  "/usr/$PHP_LIBDIR"|"/usr/lib"[)] ;;
++  /Library/Developer/CommandLineTools/SDKs/*/usr/lib[)] ;;
++  /Applications/Xcode*.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*/usr/lib[)] ;;
++  *[)]
+     PHP_EXPAND_PATH($1, ai_p)
+     ifelse([$2],,[
+       _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+@@ -452,8 +456,8 @@ AC_DEFUN([PHP_ADD_LIBPATH],[
+       else
+         _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+       fi
+-    ])
+-  fi
++    ]) ;;
++  esac
+ ])
+
+ dnl
+@@ -487,7 +491,11 @@ dnl add an include path.
+ dnl if before is 1, add in the beginning of INCLUDES.
+ dnl
+ AC_DEFUN([PHP_ADD_INCLUDE],[
+-  if test "$1" != "/usr/include"; then
++  case "$1" in
++  "/usr/include"[)] ;;
++  /Library/Developer/CommandLineTools/SDKs/*/usr/include[)] ;;
++  /Applications/Xcode*.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*/usr/include[)] ;;
++  *[)]
+     PHP_EXPAND_PATH($1, ai_p)
+     PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
+       if test "$2"; then
+@@ -495,8 +503,8 @@ AC_DEFUN([PHP_ADD_INCLUDE],[
+       else
+         INCLUDES="$INCLUDES -I$ai_p"
+       fi
+-    ])
+-  fi
++    ]) ;;
++  esac
+ ])
+
+ dnl internal, don't use
+@@ -2411,7 +2419,8 @@ AC_DEFUN([PHP_SETUP_ICONV], [
+     fi
+
+     if test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.a ||
+-       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.$SHLIB_SUFFIX_NAME
++       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.$SHLIB_SUFFIX_NAME ||
++       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.tbd
+     then
+       PHP_CHECK_LIBRARY($iconv_lib_name, libiconv, [
+         found_iconv=yes

--- a/Formula/php@7.1-debug.rb
+++ b/Formula/php@7.1-debug.rb
@@ -1,0 +1,513 @@
+class PhpAT71Debug < Formula
+  desc "General-purpose scripting language"
+  homepage "https://www.php.net/"
+  url "https://github.com/shivammathur/php-src-backports/archive/34a5e348a6b4ea154a4d27e51fcfa757babb4d2a.tar.gz"
+  version "7.1.33"
+  sha256 "e3220b4dd6d0d879bd391acb5ec23a2eaa5aa742bc1afa10515f7ba7a2725dee"
+  license "PHP-3.01"
+  revision 4
+
+  bottle do
+    root_url "https://ghcr.io/v2/shivammathur/php"
+    rebuild 5
+    sha256 arm64_monterey: "c935d59866e4355ffc0092303420cfef3569e20cad464b454a1f08d41414c489"
+    sha256 arm64_big_sur:  "679c51fa82b29612eb9510122c9f4ec01358b53ae5951d2b1c5b80cbeb207a1c"
+    sha256 monterey:       "3c034eb961486190a152966c0dabc7895da422c131d438baf79b3785ff20c286"
+    sha256 big_sur:        "34bf4b64f1b21d5c518b7027dab58b90bf51d3bf94fe8becc13cdf92ff29e138"
+    sha256 catalina:       "92d6fc62d3005724f45300fcc4e5b9a94cf61c0c7516bc17cfb991d062e68d70"
+    sha256 x86_64_linux:   "ac81b8cde6ad4a68a1e8212f32d96582c3338dc643eace58ef3ac23c60e4ff5f"
+  end
+
+  keg_only :versioned_formula
+
+  # This PHP version is not supported upstream as of 2019-12-01.
+  # Although, this was built with back-ported security patches,
+  # we recommended to use a currently supported PHP version.
+  # For more details, refer to https://www.php.net/eol.php
+  deprecate! date: "2019-12-01", because: :deprecated_upstream
+
+  depends_on "bison" => :build
+  depends_on "httpd" => [:build, :test]
+  depends_on "pkg-config" => :build
+  depends_on "re2c" => :build
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "aspell"
+  depends_on "autoconf"
+  depends_on "curl"
+  depends_on "freetds"
+  depends_on "freetype"
+  depends_on "gettext"
+  depends_on "gmp"
+  depends_on "icu4c"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libpq"
+  depends_on "libtool"
+  depends_on "libzip"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "sqlite"
+  depends_on "tidy-html5"
+  depends_on "unixodbc"
+  depends_on "webp"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "libedit"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
+
+  on_macos do
+    # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/pull/3472
+    patch :DATA
+  end
+
+  def install
+    # Work around configure issues with Xcode 12
+    # See https://bugs.php.net/bug.php?id=80171
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
+    # Workaround for https://bugs.php.net/80310
+    ENV.append "CFLAGS", "-DU_DEFINE_FALSE_AND_TRUE=1"
+    ENV.append "CXXFLAGS", "-DU_DEFINE_FALSE_AND_TRUE=1"
+
+    # buildconf required due to system library linking bug patch
+    system "./buildconf", "--force"
+
+    inreplace "configure" do |s|
+      s.gsub! "APACHE_THREADED_MPM=`$APXS_HTTPD -V | grep 'threaded:.*yes'`",
+              "APACHE_THREADED_MPM="
+      s.gsub! "APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`",
+              "APXS_LIBEXECDIR='$(INSTALL_ROOT)#{lib}/httpd/modules'"
+      s.gsub! "-z `$APXS -q SYSCONFDIR`",
+              "-z ''"
+      # apxs will interpolate the @ in the versioned prefix: https://bz.apache.org/bugzilla/show_bug.cgi?id=61944
+      s.gsub! "LIBEXECDIR='$APXS_LIBEXECDIR'",
+              "LIBEXECDIR='" + "#{lib}/httpd/modules".gsub("@", "\\@") + "'"
+    end
+
+    # Update error message in apache sapi to better explain the requirements
+    # of using Apache http in combination with php if the non-compatible MPM
+    # has been selected. Homebrew has chosen not to support being able to
+    # compile a thread safe version of PHP and therefore it is not
+    # possible to recompile as suggested in the original message
+    inreplace "sapi/apache2handler/sapi_apache2.c",
+              "You need to recompile PHP.",
+              "Homebrew PHP does not support a thread-safe php binary. " \
+              "To use the PHP apache sapi please change " \
+              "your httpd config to use the prefork MPM"
+
+    inreplace "sapi/fpm/php-fpm.conf.in", ";daemonize = yes", "daemonize = no"
+
+    # Required due to icu4c dependency
+    ENV.cxx11
+
+    config_path = etc/"php/#{php_version}"
+    # Prevent system pear config from inhibiting pear install
+    (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?
+
+    # Prevent homebrew from harcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    # Each extension that is built on Mojave needs a direct reference to the
+    # sdk path or it won't find the headers
+    headers_path = ""
+    headers_path = "=#{MacOS.sdk_path_if_needed}/usr" if OS.mac?
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --with-pear=#{pkgshare}/pear
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-debug
+      --enable-exif
+      --enable-ftp
+      --enable-fpm
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-opcache-file
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-phpdbg-webhelper
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --enable-wddx
+      --enable-zip
+      --with-apxs2=#{Formula["httpd"].opt_bin}/apxs
+      --with-curl=#{Formula["curl"].opt_prefix}
+      --with-fpm-user=_www
+      --with-fpm-group=_www
+      --with-freetype-dir=#{Formula["freetype"].opt_prefix}
+      --with-gd
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-iconv#{headers_path}
+      --with-icu-dir=#{Formula["icu4c"].opt_prefix}
+      --with-jpeg-dir=#{Formula["jpeg"].opt_prefix}
+      --with-kerberos#{headers_path}
+      --with-layout=GNU
+      --with-ldap=#{Formula["openldap"].opt_prefix}
+      --with-ldap-sasl#{headers_path}
+      --with-libzip
+      --with-mhash#{headers_path}
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pdo-sqlite=#{Formula["sqlite"].opt_prefix}
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-png-dir=#{Formula["libpng"].opt_prefix}
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sqlite3=#{Formula["sqlite"].opt_prefix}
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
+      --with-unixODBC=#{Formula["unixodbc"].opt_prefix}
+      --with-webp-dir=#{Formula["webp"].opt_prefix}
+      --with-xmlrpc
+    ]
+
+    if OS.mac?
+      args << "--enable-dtrace"
+      args << "--with-bz2#{headers_path}"
+      args << "--with-libedit#{headers_path}"
+      args << "--with-libxml-dir#{headers_path}"
+      args << "--with-ndbm#{headers_path}"
+      args << "--with-xsl#{headers_path}"
+      args << "--with-zlib#{headers_path}"
+    end
+
+    if OS.linux?
+      args << "--disable-dtrace"
+      args << "--with-zlib=#{Formula["zlib"].opt_prefix}"
+      args << "--with-bzip2=#{Formula["bzip2"].opt_prefix}"
+      args << "--with-libedit=#{Formula["libedit"].opt_prefix}"
+      args << "--with-libxml-dir=#{Formula["libxml2"].opt_prefix}"
+      args << "--with-xsl=#{Formula["libxslt"].opt_prefix}"
+      args << "--without-ldap-sasl"
+      args << "--without-ndbm"
+      args << "--without-gdbm"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", %r{; ?extension_dir = "\./"},
+        "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+    end
+
+    # Use OpenSSL cert bundle
+    openssl = Formula["openssl@1.1"]
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", /; ?openssl\.cafile=/,
+        "openssl.cafile = \"#{openssl.pkgetc}/cert.pem\""
+      inreplace "php.ini-#{mode}", /; ?openssl\.capath=/,
+        "openssl.capath = \"#{openssl.pkgetc}/certs\""
+    end
+
+    config_files = {
+      "php.ini-development"   => "php.ini",
+      "php.ini-production"    => "php.ini-production",
+      "sapi/fpm/php-fpm.conf" => "php-fpm.conf",
+      "sapi/fpm/www.conf"     => "php-fpm.d/www.conf",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+
+    unless (var/"log/php-fpm.log").exist?
+      (var/"log").mkpath
+      touch var/"log/php-fpm.log"
+    end
+  end
+
+  def post_install
+    pear_prefix = pkgshare/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    pecl_path.mkpath
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear@#{php_version}"
+    cp_r pkgshare/"pear/.", pear_path
+    {
+      "php_ini"  => etc/"php/#{php_version}/php.ini",
+      "php_dir"  => pear_path,
+      "doc_dir"  => pear_path/"doc",
+      "ext_dir"  => pecl_path/php_basename,
+      "bin_dir"  => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir"  => pear_path/"cfg",
+      "www_dir"  => pear_path/"htdocs",
+      "man_dir"  => HOMEBREW_PREFIX/"share/man",
+      "test_dir" => pear_path/"test",
+      "php_bin"  => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if /(?<!bin|man)_dir$/.match?(key)
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    system bin/"pear", "update-channels"
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{php_version}/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def caveats
+    <<~EOS
+      To enable PHP in Apache add the following to httpd.conf and restart Apache:
+          LoadModule php7_module #{opt_lib}/httpd/modules/libphp7.so
+
+          <FilesMatch \\.php$>
+              SetHandler application/x-httpd-php
+          </FilesMatch>
+
+      Finally, check DirectoryIndex includes index.php
+          DirectoryIndex index.php index.html
+
+      The php.ini and php-fpm.ini file can be found in:
+          #{etc}/php/#{php_version}/
+    EOS
+  end
+
+  def php_version
+    version.to_s.split(".")[0..1].join(".") + "-debug"
+  end
+
+  plist_options manual: "php-fpm"
+  service do
+    run [opt_sbin/"php-fpm", "--nodaemonize"]
+    run_type :immediate
+    keep_alive true
+    error_log_path var/"log/php-fpm.log"
+    working_dir var
+  end
+
+  test do
+    assert_match(/^Zend OPcache$/, shell_output("#{bin}/php -i"),
+      "Zend OPCache extension not loaded")
+    # Test related to libxml2 and
+    # https://github.com/Homebrew/homebrew-core/issues/28398
+    if OS.mac?
+      assert_includes MachO::Tools.dylibs("#{bin}/php"),
+              "#{Formula["libpq"].opt_lib}/libpq.5.dylib"
+    end
+
+    system "#{sbin}/php-fpm", "-t"
+    system "#{bin}/phpdbg", "-V"
+    system "#{bin}/php-cgi", "-m"
+    # Prevent SNMP extension to be added
+    refute_match(/^snmp$/, shell_output("#{bin}/php -m"),
+      "SNMP extension doesn't work reliably with Homebrew on High Sierra")
+    begin
+      require "socket"
+
+      server = TCPServer.new(0)
+      port = server.addr[1]
+      server_fpm = TCPServer.new(0)
+      port_fpm = server_fpm.addr[1]
+      server.close
+      server_fpm.close
+
+      expected_output = /^Hello world!$/
+      (testpath/"index.php").write <<~EOS
+        <?php
+        echo 'Hello world!' . PHP_EOL;
+        var_dump(ldap_connect());
+      EOS
+      main_config = <<~EOS
+        Listen #{port}
+        ServerName localhost:#{port}
+        DocumentRoot "#{testpath}"
+        ErrorLog "#{testpath}/httpd-error.log"
+        ServerRoot "#{Formula["httpd"].opt_prefix}"
+        PidFile "#{testpath}/httpd.pid"
+        LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
+        LoadModule unixd_module lib/httpd/modules/mod_unixd.so
+        LoadModule dir_module lib/httpd/modules/mod_dir.so
+        DirectoryIndex index.php
+      EOS
+
+      (testpath/"httpd.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
+        LoadModule php7_module #{lib}/httpd/modules/libphp7.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler application/x-httpd-php
+        </FilesMatch>
+      EOS
+
+      (testpath/"fpm.conf").write <<~EOS
+        [global]
+        daemonize=no
+        [www]
+        listen = 127.0.0.1:#{port_fpm}
+        pm = dynamic
+        pm.max_children = 5
+        pm.start_servers = 2
+        pm.min_spare_servers = 1
+        pm.max_spare_servers = 3
+      EOS
+
+      (testpath/"httpd-fpm.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
+        LoadModule proxy_module lib/httpd/modules/mod_proxy.so
+        LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
+        </FilesMatch>
+      EOS
+
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+
+      fpm_pid = fork do
+        exec sbin/"php-fpm", "-y", "fpm.conf"
+      end
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd-fpm.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+    ensure
+      if pid
+        Process.kill("TERM", pid)
+        Process.wait(pid)
+      end
+      if fpm_pid
+        Process.kill("TERM", fpm_pid)
+        Process.wait(fpm_pid)
+      end
+    end
+  end
+end
+
+__END__
+diff --git a/acinclude.m4 b/acinclude.m4
+index 168c465f8d..6c087d152f 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -441,7 +441,11 @@ dnl
+ dnl Adds a path to linkpath/runpath (LDFLAGS)
+ dnl
+ AC_DEFUN([PHP_ADD_LIBPATH],[
+-  if test "$1" != "/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
++  case "$1" in
++  "/usr/$PHP_LIBDIR"|"/usr/lib"[)] ;;
++  /Library/Developer/CommandLineTools/SDKs/*/usr/lib[)] ;;
++  /Applications/Xcode*.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*/usr/lib[)] ;;
++  *[)]
+     PHP_EXPAND_PATH($1, ai_p)
+     ifelse([$2],,[
+       _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+@@ -452,8 +456,8 @@ AC_DEFUN([PHP_ADD_LIBPATH],[
+       else
+         _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+       fi
+-    ])
+-  fi
++    ]) ;;
++  esac
+ ])
+
+ dnl
+@@ -487,7 +491,11 @@ dnl add an include path.
+ dnl if before is 1, add in the beginning of INCLUDES.
+ dnl
+ AC_DEFUN([PHP_ADD_INCLUDE],[
+-  if test "$1" != "/usr/include"; then
++  case "$1" in
++  "/usr/include"[)] ;;
++  /Library/Developer/CommandLineTools/SDKs/*/usr/include[)] ;;
++  /Applications/Xcode*.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*/usr/include[)] ;;
++  *[)]
+     PHP_EXPAND_PATH($1, ai_p)
+     PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
+       if test "$2"; then
+@@ -495,8 +503,8 @@ AC_DEFUN([PHP_ADD_INCLUDE],[
+       else
+         INCLUDES="$INCLUDES -I$ai_p"
+       fi
+-    ])
+-  fi
++    ]) ;;
++  esac
+ ])
+
+ dnl internal, don't use
+@@ -2411,7 +2419,8 @@ AC_DEFUN([PHP_SETUP_ICONV], [
+     fi
+
+     if test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.a ||
+-       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.$SHLIB_SUFFIX_NAME
++       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.$SHLIB_SUFFIX_NAME ||
++       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.tbd
+     then
+       PHP_CHECK_LIBRARY($iconv_lib_name, libiconv, [
+         found_iconv=yes

--- a/Formula/php@7.2-debug.rb
+++ b/Formula/php@7.2-debug.rb
@@ -1,0 +1,508 @@
+class PhpAT72Debug < Formula
+  desc "General-purpose scripting language"
+  homepage "https://www.php.net/"
+  url "https://github.com/shivammathur/php-src-backports/archive/9441c5dbf3e4b7049f720742578bad9bd95a9571.tar.gz"
+  version "7.2.34"
+  sha256 "2e7b8049706e6d169729aafab091d98d0735767282ab44c275990418563bc160"
+  license "PHP-3.01"
+  revision 4
+
+  bottle do
+    root_url "https://ghcr.io/v2/shivammathur/php"
+    rebuild 5
+    sha256 arm64_monterey: "bbbc565fa3632534fbe54f138a06d5c969e0ee7ee2ff18d1c2ae938a787de772"
+    sha256 arm64_big_sur:  "696e563b50d6e1afb7fb6677169c2fbe9b872c1b08769abc7aadc38e2e588e66"
+    sha256 monterey:       "897e675903b3c2c788035a74adee26013a3011ed51aae8f34abce6f3f8bde36b"
+    sha256 big_sur:        "16c309a091b4248ec7ee55fd2ff4fb4b9d4c1761207f5d3c38854fb4fca07fee"
+    sha256 catalina:       "c2cc5accbb5e71346f5c6d9df80c398613fc5117c1dd6e0391eed2c5f4c8d2ce"
+    sha256 x86_64_linux:   "d0260692664683ecefecba2acceef94dd0c6305d8657365da5de2a2de164d25c"
+  end
+
+  keg_only :versioned_formula
+
+  # This PHP version is not supported upstream as of 2020-11-30.
+  # Although, this was built with back-ported security patches,
+  # we recommended to use a currently supported PHP version.
+  # For more details, refer to https://www.php.net/eol.php
+  deprecate! date: "2020-11-30", because: :deprecated_upstream
+
+  depends_on "bison" => :build
+  depends_on "httpd" => [:build, :test]
+  depends_on "pkg-config" => :build
+  depends_on "re2c" => :build
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "argon2"
+  depends_on "aspell"
+  depends_on "autoconf"
+  depends_on "curl"
+  depends_on "freetds"
+  depends_on "freetype"
+  depends_on "gettext"
+  depends_on "gmp"
+  depends_on "icu4c"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libpq"
+  depends_on "libsodium"
+  depends_on "libzip"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "sqlite"
+  depends_on "tidy-html5"
+  depends_on "unixodbc"
+  depends_on "webp"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "libedit"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
+
+  on_macos do
+    # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/pull/3472
+    patch :DATA
+  end
+
+  def install
+    # Work around configure issues with Xcode 12
+    # See https://bugs.php.net/bug.php?id=80171
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
+    # Workaround for https://bugs.php.net/80310
+    ENV.append "CFLAGS", "-DU_DEFINE_FALSE_AND_TRUE=1"
+    ENV.append "CXXFLAGS", "-DU_DEFINE_FALSE_AND_TRUE=1"
+
+    # buildconf required due to system library linking bug patch
+    system "./buildconf", "--force"
+
+    inreplace "configure" do |s|
+      s.gsub! "APACHE_THREADED_MPM=`$APXS_HTTPD -V | grep 'threaded:.*yes'`",
+              "APACHE_THREADED_MPM="
+      s.gsub! "APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`",
+              "APXS_LIBEXECDIR='$(INSTALL_ROOT)#{lib}/httpd/modules'"
+      s.gsub! "-z `$APXS -q SYSCONFDIR`",
+              "-z ''"
+
+      # apxs will interpolate the @ in the versioned prefix: https://bz.apache.org/bugzilla/show_bug.cgi?id=61944
+      s.gsub! "LIBEXECDIR='$APXS_LIBEXECDIR'",
+              "LIBEXECDIR='" + "#{lib}/httpd/modules".gsub("@", "\\@") + "'"
+    end
+
+    # Update error message in apache sapi to better explain the requirements
+    # of using Apache http in combination with php if the non-compatible MPM
+    # has been selected. Homebrew has chosen not to support being able to
+    # compile a thread safe version of PHP and therefore it is not
+    # possible to recompile as suggested in the original message
+    inreplace "sapi/apache2handler/sapi_apache2.c",
+              "You need to recompile PHP.",
+              "Homebrew PHP does not support a thread-safe php binary. " \
+              "To use the PHP apache sapi please change " \
+              "your httpd config to use the prefork MPM"
+
+    inreplace "sapi/fpm/php-fpm.conf.in", ";daemonize = yes", "daemonize = no"
+
+    # Required due to icu4c dependency
+    ENV.cxx11
+
+    config_path = etc/"php/#{version.major_minor}-debug"
+    # Prevent system pear config from inhibiting pear install
+    (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?
+
+    # Prevent homebrew from harcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    # Each extension that is built on Mojave needs a direct reference to the
+    # sdk path or it won't find the headers
+    headers_path = ""
+    headers_path = "=#{MacOS.sdk_path_if_needed}/usr" if OS.mac?
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --with-pear=#{pkgshare}/pear
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-debug
+      --enable-exif
+      --enable-ftp
+      --enable-fpm
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-opcache-file
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-phpdbg-readline
+      --enable-phpdbg-webhelper
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --enable-wddx
+      --enable-zip
+      --with-apxs2=#{Formula["httpd"].opt_bin}/apxs
+      --with-curl=#{Formula["curl"].opt_prefix}
+      --with-fpm-user=_www
+      --with-fpm-group=_www
+      --with-freetype-dir=#{Formula["freetype"].opt_prefix}
+      --with-gd
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-iconv#{headers_path}
+      --with-icu-dir=#{Formula["icu4c"].opt_prefix}
+      --with-jpeg-dir=#{Formula["jpeg"].opt_prefix}
+      --with-kerberos#{headers_path}
+      --with-layout=GNU
+      --with-ldap=#{Formula["openldap"].opt_prefix}
+      --with-ldap-sasl#{headers_path}
+      --with-libzip
+      --with-mhash#{headers_path}
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-password-argon2=#{Formula["argon2"].opt_prefix}
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pdo-sqlite=#{Formula["sqlite"].opt_prefix}
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-png-dir=#{Formula["libpng"].opt_prefix}
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sodium=#{Formula["libsodium"].opt_prefix}
+      --with-sqlite3=#{Formula["sqlite"].opt_prefix}
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
+      --with-unixODBC=#{Formula["unixodbc"].opt_prefix}
+      --with-webp-dir=#{Formula["webp"].opt_prefix}
+      --with-xmlrpc
+    ]
+
+    if OS.mac?
+      args << "--enable-dtrace"
+      args << "--with-bz2#{headers_path}"
+      args << "--with-libedit#{headers_path}"
+      args << "--with-libxml-dir#{headers_path}"
+      args << "--with-ndbm#{headers_path}"
+      args << "--with-xsl#{headers_path}"
+      args << "--with-zlib#{headers_path}"
+    end
+
+    if OS.linux?
+      args << "--disable-dtrace"
+      args << "--with-zlib=#{Formula["zlib"].opt_prefix}"
+      args << "--with-bzip2=#{Formula["bzip2"].opt_prefix}"
+      args << "--with-libedit=#{Formula["libedit"].opt_prefix}"
+      args << "--with-libxml-dir=#{Formula["libxml2"].opt_prefix}"
+      args << "--with-xsl=#{Formula["libxslt"].opt_prefix}"
+      args << "--without-ldap-sasl"
+      args << "--without-ndbm"
+      args << "--without-gdbm"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", %r{; ?extension_dir = "\./"},
+        "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+    end
+
+    # Use OpenSSL cert bundle
+    openssl = Formula["openssl@1.1"]
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", /; ?openssl\.cafile=/,
+        "openssl.cafile = \"#{openssl.pkgetc}/cert.pem\""
+      inreplace "php.ini-#{mode}", /; ?openssl\.capath=/,
+        "openssl.capath = \"#{openssl.pkgetc}/certs\""
+    end
+
+    config_files = {
+      "php.ini-development"   => "php.ini",
+      "php.ini-production"    => "php.ini-production",
+      "sapi/fpm/php-fpm.conf" => "php-fpm.conf",
+      "sapi/fpm/www.conf"     => "php-fpm.d/www.conf",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+
+    unless (var/"log/php-fpm.log").exist?
+      (var/"log").mkpath
+      touch var/"log/php-fpm.log"
+    end
+  end
+
+  def post_install
+    pear_prefix = pkgshare/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    pecl_path.mkpath
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear@#{version.major_minor}-debug"
+    cp_r pkgshare/"pear/.", pear_path
+    {
+      "php_ini"  => etc/"php/#{version.major_minor}-debug/php.ini",
+      "php_dir"  => pear_path,
+      "doc_dir"  => pear_path/"doc",
+      "ext_dir"  => pecl_path/php_basename,
+      "bin_dir"  => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir"  => pear_path/"cfg",
+      "www_dir"  => pear_path/"htdocs",
+      "man_dir"  => HOMEBREW_PREFIX/"share/man",
+      "test_dir" => pear_path/"test",
+      "php_bin"  => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if /(?<!bin|man)_dir$/.match?(key)
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    system bin/"pear", "update-channels"
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{version.major_minor}-debug/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def caveats
+    <<~EOS
+      To enable PHP in Apache add the following to httpd.conf and restart Apache:
+          LoadModule php7_module #{opt_lib}/httpd/modules/libphp7.so
+
+          <FilesMatch \\.php$>
+              SetHandler application/x-httpd-php
+          </FilesMatch>
+
+      Finally, check DirectoryIndex includes index.php
+          DirectoryIndex index.php index.html
+
+      The php.ini and php-fpm.ini file can be found in:
+          #{etc}/php/#{version.major_minor}-debug/
+    EOS
+  end
+
+  plist_options manual: "php-fpm"
+  service do
+    run [opt_sbin/"php-fpm", "--nodaemonize"]
+    run_type :immediate
+    keep_alive true
+    error_log_path var/"log/php-fpm.log"
+    working_dir var
+  end
+
+  test do
+    assert_match(/^Zend OPcache$/, shell_output("#{bin}/php -i"),
+      "Zend OPCache extension not loaded")
+    # Test related to libxml2 and
+    # https://github.com/Homebrew/homebrew-core/issues/28398
+    if OS.mac?
+      assert_includes MachO::Tools.dylibs("#{bin}/php"),
+              "#{Formula["libpq"].opt_lib}/libpq.5.dylib"
+    end
+
+    system "#{sbin}/php-fpm", "-t"
+    system "#{bin}/phpdbg", "-V"
+    system "#{bin}/php-cgi", "-m"
+    # Prevent SNMP extension to be added
+    refute_match(/^snmp$/, shell_output("#{bin}/php -m"),
+      "SNMP extension doesn't work reliably with Homebrew on High Sierra")
+    begin
+      port = free_port
+      port_fpm = free_port
+
+      expected_output = /^Hello world!$/
+      (testpath/"index.php").write <<~EOS
+        <?php
+        echo 'Hello world!' . PHP_EOL;
+        var_dump(ldap_connect());
+      EOS
+      main_config = <<~EOS
+        Listen #{port}
+        ServerName localhost:#{port}
+        DocumentRoot "#{testpath}"
+        ErrorLog "#{testpath}/httpd-error.log"
+        ServerRoot "#{Formula["httpd"].opt_prefix}"
+        PidFile "#{testpath}/httpd.pid"
+        LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
+        LoadModule unixd_module lib/httpd/modules/mod_unixd.so
+        LoadModule dir_module lib/httpd/modules/mod_dir.so
+        DirectoryIndex index.php
+      EOS
+
+      (testpath/"httpd.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
+        LoadModule php7_module #{lib}/httpd/modules/libphp7.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler application/x-httpd-php
+        </FilesMatch>
+      EOS
+
+      (testpath/"fpm.conf").write <<~EOS
+        [global]
+        daemonize=no
+        [www]
+        listen = 127.0.0.1:#{port_fpm}
+        pm = dynamic
+        pm.max_children = 5
+        pm.start_servers = 2
+        pm.min_spare_servers = 1
+        pm.max_spare_servers = 3
+      EOS
+
+      (testpath/"httpd-fpm.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
+        LoadModule proxy_module lib/httpd/modules/mod_proxy.so
+        LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
+        </FilesMatch>
+      EOS
+
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+
+      fpm_pid = fork do
+        exec sbin/"php-fpm", "-y", "fpm.conf"
+      end
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd-fpm.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+    ensure
+      if pid
+        Process.kill("TERM", pid)
+        Process.wait(pid)
+      end
+      if fpm_pid
+        Process.kill("TERM", fpm_pid)
+        Process.wait(fpm_pid)
+      end
+    end
+  end
+end
+
+__END__
+diff --git a/acinclude.m4 b/acinclude.m4
+index 168c465f8d..6c087d152f 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -441,7 +441,11 @@ dnl
+ dnl Adds a path to linkpath/runpath (LDFLAGS)
+ dnl
+ AC_DEFUN([PHP_ADD_LIBPATH],[
+-  if test "$1" != "/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
++  case "$1" in
++  "/usr/$PHP_LIBDIR"|"/usr/lib"[)] ;;
++  /Library/Developer/CommandLineTools/SDKs/*/usr/lib[)] ;;
++  /Applications/Xcode*.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*/usr/lib[)] ;;
++  *[)]
+     PHP_EXPAND_PATH($1, ai_p)
+     ifelse([$2],,[
+       _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+@@ -452,8 +456,8 @@ AC_DEFUN([PHP_ADD_LIBPATH],[
+       else
+         _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+       fi
+-    ])
+-  fi
++    ]) ;;
++  esac
+ ])
+
+ dnl
+@@ -487,7 +491,11 @@ dnl add an include path.
+ dnl if before is 1, add in the beginning of INCLUDES.
+ dnl
+ AC_DEFUN([PHP_ADD_INCLUDE],[
+-  if test "$1" != "/usr/include"; then
++  case "$1" in
++  "/usr/include"[)] ;;
++  /Library/Developer/CommandLineTools/SDKs/*/usr/include[)] ;;
++  /Applications/Xcode*.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*/usr/include[)] ;;
++  *[)]
+     PHP_EXPAND_PATH($1, ai_p)
+     PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
+       if test "$2"; then
+@@ -495,8 +503,8 @@ AC_DEFUN([PHP_ADD_INCLUDE],[
+       else
+         INCLUDES="$INCLUDES -I$ai_p"
+       fi
+-    ])
+-  fi
++    ]) ;;
++  esac
+ ])
+
+ dnl internal, don't use
+@@ -2411,7 +2419,8 @@ AC_DEFUN([PHP_SETUP_ICONV], [
+     fi
+
+     if test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.a ||
+-       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.$SHLIB_SUFFIX_NAME
++       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.$SHLIB_SUFFIX_NAME ||
++       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.tbd
+     then
+       PHP_CHECK_LIBRARY($iconv_lib_name, libiconv, [
+         found_iconv=yes

--- a/Formula/php@7.3-debug.rb
+++ b/Formula/php@7.3-debug.rb
@@ -1,0 +1,507 @@
+class PhpAT73Debug < Formula
+  desc "General-purpose scripting language"
+  homepage "https://www.php.net/"
+  url "https://github.com/shivammathur/php-src-backports/archive/44e9b81607f38d1d52cee0129ed448c0506a3aa2.tar.gz"
+  version "7.3.33"
+  sha256 "7fcfe594bb3fb48ba8060550513e494fc47b10211045ab467a63df180a095669"
+  license "PHP-3.01"
+  revision 2
+
+  bottle do
+    root_url "https://ghcr.io/v2/shivammathur/php"
+    rebuild 5
+    sha256 arm64_monterey: "dae72972099acd27c321fcebfd42d5833fc7e6a1b026375c3cc72f48b67fbbdc"
+    sha256 arm64_big_sur:  "a5f78b927d3910cf4844028c7d18db8403bdeffd7d10cd208d3fc39667b6e4d1"
+    sha256 monterey:       "e28d81e822313719034b2def96c414e8a726781073239d10da5b470c44e08674"
+    sha256 big_sur:        "525acd54b78436e906b731571e6ec1f6120f5cddf4ab5ab421bb8435ee72d8a1"
+    sha256 catalina:       "13274de1fc30a58ff89a6f90fe9b2aebc502fedb16f566f77e031bfd244d9985"
+    sha256 x86_64_linux:   "463edff3773654715f1291c6ecce2dcbca4f2771fc0296377e598f9c12251e98"
+  end
+
+  keg_only :versioned_formula
+
+  # This PHP version is not supported upstream as of 2021-12-06.
+  # Although, this was built with back-ported security patches,
+  # we recommended to use a currently supported PHP version.
+  # For more details, refer to https://www.php.net/eol.php
+  deprecate! date: "2021-12-06", because: :deprecated_upstream
+
+  depends_on "bison" => :build
+  depends_on "httpd" => [:build, :test]
+  depends_on "pkg-config" => :build
+  depends_on "re2c" => :build
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "argon2"
+  depends_on "aspell"
+  depends_on "autoconf"
+  depends_on "curl"
+  depends_on "freetds"
+  depends_on "freetype"
+  depends_on "gettext"
+  depends_on "gmp"
+  depends_on "icu4c"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libpq"
+  depends_on "libsodium"
+  depends_on "libzip"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "pcre2"
+  depends_on "sqlite"
+  depends_on "tidy-html5"
+  depends_on "unixodbc"
+  depends_on "webp"
+
+  uses_from_macos "xz" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "libedit"
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
+
+  on_macos do
+    # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/pull/3472
+    patch :DATA
+  end
+
+  def install
+    # buildconf required due to system library linking bug patch
+    system "./buildconf", "--force"
+
+    inreplace "configure" do |s|
+      s.gsub! "APACHE_THREADED_MPM=`$APXS_HTTPD -V | grep 'threaded:.*yes'`",
+              "APACHE_THREADED_MPM="
+      s.gsub! "APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`",
+              "APXS_LIBEXECDIR='$(INSTALL_ROOT)#{lib}/httpd/modules'"
+      s.gsub! "-z `$APXS -q SYSCONFDIR`",
+              "-z ''"
+
+      # apxs will interpolate the @ in the versioned prefix: https://bz.apache.org/bugzilla/show_bug.cgi?id=61944
+      s.gsub! "LIBEXECDIR='$APXS_LIBEXECDIR'",
+      "LIBEXECDIR='" + "#{lib}/httpd/modules".gsub("@", "\\@") + "'"
+    end
+
+    # Update error message in apache sapi to better explain the requirements
+    # of using Apache http in combination with php if the non-compatible MPM
+    # has been selected. Homebrew has chosen not to support being able to
+    # compile a thread safe version of PHP and therefore it is not
+    # possible to recompile as suggested in the original message
+    inreplace "sapi/apache2handler/sapi_apache2.c",
+              "You need to recompile PHP.",
+              "Homebrew PHP does not support a thread-safe php binary. " \
+              "To use the PHP apache sapi please change " \
+              "your httpd config to use the prefork MPM"
+
+    inreplace "sapi/fpm/php-fpm.conf.in", ";daemonize = yes", "daemonize = no"
+
+    # Required due to icu4c dependency
+    ENV.cxx11
+
+    config_path = etc/"php/#{version.major_minor}-debug"
+    # Prevent system pear config from inhibiting pear install
+    (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?
+
+    # Prevent homebrew from harcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    # Each extension that is built on Mojave needs a direct reference to the
+    # sdk path or it won't find the headers
+    headers_path = ""
+    headers_path = "=#{MacOS.sdk_path_if_needed}/usr" if OS.mac?
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --with-pear=#{pkgshare}/pear
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-debug
+      --enable-exif
+      --enable-ftp
+      --enable-fpm
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-opcache-file
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-phpdbg-readline
+      --enable-phpdbg-webhelper
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --enable-wddx
+      --enable-zip
+      --with-apxs2=#{Formula["httpd"].opt_bin}/apxs
+      --with-curl=#{Formula["curl"].opt_prefix}
+      --with-fpm-user=_www
+      --with-fpm-group=_www
+      --with-freetype-dir=#{Formula["freetype"].opt_prefix}
+      --with-gd
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-iconv#{headers_path}
+      --with-icu-dir=#{Formula["icu4c"].opt_prefix}
+      --with-jpeg-dir=#{Formula["jpeg"].opt_prefix}
+      --with-kerberos#{headers_path}
+      --with-layout=GNU
+      --with-ldap=#{Formula["openldap"].opt_prefix}
+      --with-libzip
+      --with-mhash#{headers_path}
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-password-argon2=#{Formula["argon2"].opt_prefix}
+      --with-pcre-regex=#{Formula["pcre2"].opt_prefix}
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pdo-sqlite=#{Formula["sqlite"].opt_prefix}
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-png-dir=#{Formula["libpng"].opt_prefix}
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sodium=#{Formula["libsodium"].opt_prefix}
+      --with-sqlite3=#{Formula["sqlite"].opt_prefix}
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
+      --with-unixODBC=#{Formula["unixodbc"].opt_prefix}
+      --with-webp-dir=#{Formula["webp"].opt_prefix}
+      --with-xmlrpc
+    ]
+
+    if OS.mac?
+      args << "--enable-dtrace"
+      args << "--with-ldap-sasl#{headers_path}"
+      args << "--with-zlib#{headers_path}"
+      args << "--with-bz2#{headers_path}"
+      args << "--with-ndbm#{headers_path}"
+      args << "--with-libedit#{headers_path}"
+      args << "--with-libxml-dir#{headers_path}"
+      args << "--with-xsl#{headers_path}"
+    end
+    if OS.linux?
+      args << "--disable-dtrace"
+      args << "--with-zlib=#{Formula["zlib"].opt_prefix}"
+      args << "--with-bz2=#{Formula["bzip2"].opt_prefix}"
+      args << "--with-libedit=#{Formula["libedit"].opt_prefix}"
+      args << "--with-libxml-dir=#{Formula["libxml2"].opt_prefix}"
+      args << "--with-xsl=#{Formula["libxslt"].opt_prefix}"
+      args << "--without-ldap-sasl"
+      args << "--without-ndbm"
+      args << "--without-gdbm"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", %r{; ?extension_dir = "\./"},
+        "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+    end
+
+    # Use OpenSSL cert bundle
+    openssl = Formula["openssl@1.1"]
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", /; ?openssl\.cafile=/,
+        "openssl.cafile = \"#{openssl.pkgetc}/cert.pem\""
+      inreplace "php.ini-#{mode}", /; ?openssl\.capath=/,
+        "openssl.capath = \"#{openssl.pkgetc}/certs\""
+    end
+
+    # php 7.3 known bug
+    # SO discussion: https://stackoverflow.com/a/53709484/791609
+    # bug report: https://bugs.php.net/bug.php?id=77260
+    inreplace "php.ini-development", ";pcre.jit=1", "pcre.jit=0"
+
+    config_files = {
+      "php.ini-development"   => "php.ini",
+      "php.ini-production"    => "php.ini-production",
+      "sapi/fpm/php-fpm.conf" => "php-fpm.conf",
+      "sapi/fpm/www.conf"     => "php-fpm.d/www.conf",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+
+    unless (var/"log/php-fpm.log").exist?
+      (var/"log").mkpath
+      touch var/"log/php-fpm.log"
+    end
+  end
+
+  def post_install
+    pear_prefix = pkgshare/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    pecl_path.mkpath
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear@#{version.major_minor}-debug"
+    cp_r pkgshare/"pear/.", pear_path
+    {
+      "php_ini"  => etc/"php/#{version.major_minor}-debug/php.ini",
+      "php_dir"  => pear_path,
+      "doc_dir"  => pear_path/"doc",
+      "ext_dir"  => pecl_path/php_basename,
+      "bin_dir"  => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir"  => pear_path/"cfg",
+      "www_dir"  => pear_path/"htdocs",
+      "man_dir"  => HOMEBREW_PREFIX/"share/man",
+      "test_dir" => pear_path/"test",
+      "php_bin"  => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if /(?<!bin|man)_dir$/.match?(key)
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    system bin/"pear", "update-channels"
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{version.major_minor}-debug/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def caveats
+    <<~EOS
+      To enable PHP in Apache add the following to httpd.conf and restart Apache:
+          LoadModule php7_module #{opt_lib}/httpd/modules/libphp7.so
+
+          <FilesMatch \\.php$>
+              SetHandler application/x-httpd-php
+          </FilesMatch>
+
+      Finally, check DirectoryIndex includes index.php
+          DirectoryIndex index.php index.html
+
+      The php.ini and php-fpm.ini file can be found in:
+          #{etc}/php/#{version.major_minor}-debug/
+    EOS
+  end
+
+  plist_options manual: "php-fpm"
+  service do
+    run [opt_sbin/"php-fpm", "--nodaemonize"]
+    run_type :immediate
+    keep_alive true
+    error_log_path var/"log/php-fpm.log"
+    working_dir var
+  end
+
+  test do
+    assert_match(/^Zend OPcache$/, shell_output("#{bin}/php -i"),
+      "Zend OPCache extension not loaded")
+    # Test related to libxml2 and
+    # https://github.com/Homebrew/homebrew-core/issues/28398
+    if OS.mac?
+      assert_includes MachO::Tools.dylibs("#{bin}/php"),
+              "#{Formula["libpq"].opt_lib}/libpq.5.dylib"
+    end
+
+    system "#{sbin}/php-fpm", "-t"
+    system "#{bin}/phpdbg", "-V"
+    system "#{bin}/php-cgi", "-m"
+    # Prevent SNMP extension to be added
+    refute_match(/^snmp$/, shell_output("#{bin}/php -m"),
+      "SNMP extension doesn't work reliably with Homebrew on High Sierra")
+    begin
+      port = free_port
+      port_fpm = free_port
+
+      expected_output = /^Hello world!$/
+      (testpath/"index.php").write <<~EOS
+        <?php
+        echo 'Hello world!' . PHP_EOL;
+        var_dump(ldap_connect());
+      EOS
+      main_config = <<~EOS
+        Listen #{port}
+        ServerName localhost:#{port}
+        DocumentRoot "#{testpath}"
+        ErrorLog "#{testpath}/httpd-error.log"
+        ServerRoot "#{Formula["httpd"].opt_prefix}"
+        PidFile "#{testpath}/httpd.pid"
+        LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
+        LoadModule unixd_module lib/httpd/modules/mod_unixd.so
+        LoadModule dir_module lib/httpd/modules/mod_dir.so
+        DirectoryIndex index.php
+      EOS
+
+      (testpath/"httpd.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
+        LoadModule php7_module #{lib}/httpd/modules/libphp7.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler application/x-httpd-php
+        </FilesMatch>
+      EOS
+
+      (testpath/"fpm.conf").write <<~EOS
+        [global]
+        daemonize=no
+        [www]
+        listen = 127.0.0.1:#{port_fpm}
+        pm = dynamic
+        pm.max_children = 5
+        pm.start_servers = 2
+        pm.min_spare_servers = 1
+        pm.max_spare_servers = 3
+      EOS
+
+      (testpath/"httpd-fpm.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
+        LoadModule proxy_module lib/httpd/modules/mod_proxy.so
+        LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
+        </FilesMatch>
+      EOS
+
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+
+      fpm_pid = fork do
+        exec sbin/"php-fpm", "-y", "fpm.conf"
+      end
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd-fpm.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+    ensure
+      if pid
+        Process.kill("TERM", pid)
+        Process.wait(pid)
+      end
+      if fpm_pid
+        Process.kill("TERM", fpm_pid)
+        Process.wait(fpm_pid)
+      end
+    end
+  end
+end
+
+__END__
+diff --git a/acinclude.m4 b/acinclude.m4
+index 168c465f8d..6c087d152f 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -441,7 +441,11 @@ dnl
+ dnl Adds a path to linkpath/runpath (LDFLAGS)
+ dnl
+ AC_DEFUN([PHP_ADD_LIBPATH],[
+-  if test "$1" != "/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
++  case "$1" in
++  "/usr/$PHP_LIBDIR"|"/usr/lib"[)] ;;
++  /Library/Developer/CommandLineTools/SDKs/*/usr/lib[)] ;;
++  /Applications/Xcode*.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*/usr/lib[)] ;;
++  *[)]
+     PHP_EXPAND_PATH($1, ai_p)
+     ifelse([$2],,[
+       _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+@@ -452,8 +456,8 @@ AC_DEFUN([PHP_ADD_LIBPATH],[
+       else
+         _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+       fi
+-    ])
+-  fi
++    ]) ;;
++  esac
+ ])
+
+ dnl
+@@ -487,7 +491,11 @@ dnl add an include path.
+ dnl if before is 1, add in the beginning of INCLUDES.
+ dnl
+ AC_DEFUN([PHP_ADD_INCLUDE],[
+-  if test "$1" != "/usr/include"; then
++  case "$1" in
++  "/usr/include"[)] ;;
++  /Library/Developer/CommandLineTools/SDKs/*/usr/include[)] ;;
++  /Applications/Xcode*.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*/usr/include[)] ;;
++  *[)]
+     PHP_EXPAND_PATH($1, ai_p)
+     PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
+       if test "$2"; then
+@@ -495,8 +503,8 @@ AC_DEFUN([PHP_ADD_INCLUDE],[
+       else
+         INCLUDES="$INCLUDES -I$ai_p"
+       fi
+-    ])
+-  fi
++    ]) ;;
++  esac
+ ])
+
+ dnl internal, don't use
+@@ -2411,7 +2419,8 @@ AC_DEFUN([PHP_SETUP_ICONV], [
+     fi
+
+     if test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.a ||
+-       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.$SHLIB_SUFFIX_NAME
++       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.$SHLIB_SUFFIX_NAME ||
++       test -f $ICONV_DIR/$PHP_LIBDIR/lib$iconv_lib_name.tbd
+     then
+       PHP_CHECK_LIBRARY($iconv_lib_name, libiconv, [
+         found_iconv=yes

--- a/Formula/php@7.4-debug.rb
+++ b/Formula/php@7.4-debug.rb
@@ -1,0 +1,485 @@
+class PhpAT74Debug < Formula
+  desc "General-purpose scripting language"
+  homepage "https://www.php.net/"
+  # Should only be updated if the new version is announced on the homepage, https://www.php.net/
+  url "https://www.php.net/distributions/php-7.4.30.tar.xz"
+  mirror "https://fossies.org/linux/www/php-7.4.30.tar.xz"
+  sha256 "ea72a34f32c67e79ac2da7dfe96177f3c451c3eefae5810ba13312ed398ba70d"
+  license "PHP-3.01"
+
+  livecheck do
+    url "https://www.php.net/downloads"
+    regex(/href=.*?php[._-]v?(#{Regexp.escape(version.major_minor)}(?:\.\d+)*)\.t/i)
+  end
+
+  bottle do
+    root_url "https://ghcr.io/v2/shivammathur/php"
+    sha256 arm64_monterey: "70701de358c504d28b52b47a580bb53ea4afc69e9dad9f0d010a42cccd9a60aa"
+    sha256 arm64_big_sur:  "1e8e45eca925e57344f0d1e245f94b120f2ac7abb553c1efc32117b02e0e692d"
+    sha256 monterey:       "98fb28f4d0c574410e9e1c218ea4916596ce1a433f6db8b038e28795f86c2c5a"
+    sha256 big_sur:        "5a95258c2078873d4dc7c0e044d9c654e92b858b22a370c5bd60e302f52aa50e"
+    sha256 catalina:       "5d39a88e7f09c250c5154c85ae9072b7d254e19b1998f7571d7ff0b8ab3db9f4"
+    sha256 x86_64_linux:   "faa627a55e5220fd9d62152f676cba5e70720ca53eaa5e74b553b8c1d2b0edd4"
+  end
+
+  keg_only :versioned_formula
+
+  deprecate! date: "2022-11-28", because: :versioned_formula
+
+  depends_on "httpd" => [:build, :test]
+  depends_on "pkg-config" => :build
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "argon2"
+  depends_on "aspell"
+  depends_on "autoconf"
+  depends_on "curl"
+  depends_on "freetds"
+  depends_on "gd"
+  depends_on "gettext"
+  depends_on "gmp"
+  depends_on "icu4c"
+  depends_on "krb5"
+  depends_on "libffi"
+  depends_on "libpq"
+  depends_on "libsodium"
+  depends_on "libzip"
+  depends_on "oniguruma"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "pcre2"
+  depends_on "sqlite"
+  depends_on "tidy-html5"
+  depends_on "unixodbc"
+
+  uses_from_macos "xz" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "libedit"
+  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
+
+  on_macos do
+    # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/pull/3472
+    patch :DATA
+  end
+
+  def install
+    # buildconf required due to system library linking bug patch
+    system "./buildconf", "--force"
+
+    inreplace "configure" do |s|
+      s.gsub! "APACHE_THREADED_MPM=`$APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes'`",
+              "APACHE_THREADED_MPM="
+      s.gsub! "APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`",
+              "APXS_LIBEXECDIR='$(INSTALL_ROOT)#{lib}/httpd/modules'"
+      s.gsub! "-z `$APXS -q SYSCONFDIR`",
+              "-z ''"
+
+      # apxs will interpolate the @ in the versioned prefix: https://bz.apache.org/bugzilla/show_bug.cgi?id=61944
+      s.gsub! "LIBEXECDIR='$APXS_LIBEXECDIR'",
+              "LIBEXECDIR='" + "#{lib}/httpd/modules".gsub("@", "\\@") + "'"
+    end
+
+    # Update error message in apache sapi to better explain the requirements
+    # of using Apache http in combination with php if the non-compatible MPM
+    # has been selected. Homebrew has chosen not to support being able to
+    # compile a thread safe version of PHP and therefore it is not
+    # possible to recompile as suggested in the original message
+    inreplace "sapi/apache2handler/sapi_apache2.c",
+              "You need to recompile PHP.",
+              "Homebrew PHP does not support a thread-safe php binary. " \
+              "To use the PHP apache sapi please change " \
+              "your httpd config to use the prefork MPM"
+
+    inreplace "sapi/fpm/php-fpm.conf.in", ";daemonize = yes", "daemonize = no"
+
+    config_path = etc/"php/#{version.major_minor}-debug"
+    # Prevent system pear config from inhibiting pear install
+    (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?
+
+    # Prevent homebrew from hardcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    # system pkg-config missing
+    ENV["KERBEROS_CFLAGS"] = " "
+    if OS.mac?
+      ENV["SASL_CFLAGS"] = "-I#{MacOS.sdk_path_if_needed}/usr/include/sasl"
+      ENV["SASL_LIBS"] = "-lsasl2"
+    end
+    if OS.linux?
+      ENV["SQLITE_CFLAGS"] = "-I#{Formula["sqlite"].opt_include}"
+      ENV["SQLITE_LIBS"] = "-lsqlite3"
+      ENV["BZIP_DIR"] = Formula["bzip2"].opt_prefix
+    end
+
+    # Each extension that is built on Mojave needs a direct reference to the
+    # sdk path or it won't find the headers
+    headers_path = ""
+    headers_path = "=#{MacOS.sdk_path_if_needed}/usr" if OS.mac?
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --with-pear=#{pkgshare}/pear
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-debug
+      --enable-exif
+      --enable-ftp
+      --enable-fpm
+      --enable-gd
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-phpdbg-readline
+      --enable-phpdbg-webhelper
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --with-apxs2=#{Formula["httpd"].opt_bin}/apxs
+      --with-bz2#{headers_path}
+      --with-curl
+      --with-external-gd
+      --with-external-pcre
+      --with-ffi
+      --with-fpm-user=_www
+      --with-fpm-group=_www
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-iconv#{headers_path}
+      --with-kerberos
+      --with-layout=GNU
+      --with-ldap=#{Formula["openldap"].opt_prefix}
+      --with-libxml
+      --with-libedit
+      --with-mhash#{headers_path}
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-ndbm#{headers_path}
+      --with-openssl
+      --with-password-argon2=#{Formula["argon2"].opt_prefix}
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pdo-sqlite
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sodium
+      --with-sqlite3
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
+      --with-unixODBC
+      --with-xmlrpc
+      --with-xsl
+      --with-zip
+      --with-zlib
+    ]
+
+    if OS.mac?
+      args << "--enable-dtrace"
+      args << "--with-ldap-sasl"
+      args << "--with-os-sdkpath=#{MacOS.sdk_path_if_needed}"
+    end
+    if OS.linux?
+      args << "--disable-dtrace"
+      args << "--without-ldap-sasl"
+      args << "--without-ndbm"
+      args << "--without-gdbm"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", %r{; ?extension_dir = "\./"},
+        "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+    end
+
+    # Use OpenSSL cert bundle
+    openssl = Formula["openssl@1.1"]
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", /; ?openssl\.cafile=/,
+        "openssl.cafile = \"#{openssl.pkgetc}/cert.pem\""
+      inreplace "php.ini-#{mode}", /; ?openssl\.capath=/,
+        "openssl.capath = \"#{openssl.pkgetc}/certs\""
+    end
+
+    config_files = {
+      "php.ini-development"   => "php.ini",
+      "php.ini-production"    => "php.ini-production",
+      "sapi/fpm/php-fpm.conf" => "php-fpm.conf",
+      "sapi/fpm/www.conf"     => "php-fpm.d/www.conf",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+
+    unless (var/"log/php-fpm.log").exist?
+      (var/"log").mkpath
+      touch var/"log/php-fpm.log"
+    end
+  end
+
+  def post_install
+    pear_prefix = pkgshare/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    pecl_path.mkpath
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear@#{version.major_minor}-debug"
+    cp_r pkgshare/"pear/.", pear_path
+    {
+      "php_ini"  => etc/"php/#{version.major_minor}-debug/php.ini",
+      "php_dir"  => pear_path,
+      "doc_dir"  => pear_path/"doc",
+      "ext_dir"  => pecl_path/php_basename,
+      "bin_dir"  => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir"  => pear_path/"cfg",
+      "www_dir"  => pear_path/"htdocs",
+      "man_dir"  => HOMEBREW_PREFIX/"share/man",
+      "test_dir" => pear_path/"test",
+      "php_bin"  => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if /(?<!bin|man)_dir$/.match?(key)
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    system bin/"pear", "update-channels"
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{version.major_minor}-debug/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def caveats
+    <<~EOS
+      To enable PHP in Apache add the following to httpd.conf and restart Apache:
+          LoadModule php7_module #{opt_lib}/httpd/modules/libphp7.so
+
+          <FilesMatch \\.php$>
+              SetHandler application/x-httpd-php
+          </FilesMatch>
+
+      Finally, check DirectoryIndex includes index.php
+          DirectoryIndex index.php index.html
+
+      The php.ini and php-fpm.ini file can be found in:
+          #{etc}/php/#{version.major_minor}-debug/
+    EOS
+  end
+
+  plist_options manual: "php-fpm"
+  service do
+    run [opt_sbin/"php-fpm", "--nodaemonize"]
+    run_type :immediate
+    keep_alive true
+    error_log_path var/"log/php-fpm.log"
+    working_dir var
+  end
+
+  test do
+    assert_match(/^Zend OPcache$/, shell_output("#{bin}/php -i"),
+      "Zend OPCache extension not loaded")
+    # Test related to libxml2 and
+    # https://github.com/Homebrew/homebrew-core/issues/28398
+    if OS.mac?
+      assert_includes MachO::Tools.dylibs("#{bin}/php"),
+              "#{Formula["libpq"].opt_lib}/libpq.5.dylib"
+    end
+
+    system "#{sbin}/php-fpm", "-t"
+    system "#{bin}/phpdbg", "-V"
+    system "#{bin}/php-cgi", "-m"
+    # Prevent SNMP extension to be added
+    refute_match(/^snmp$/, shell_output("#{bin}/php -m"),
+      "SNMP extension doesn't work reliably with Homebrew on High Sierra")
+    begin
+      port = free_port
+      port_fpm = free_port
+
+      expected_output = /^Hello world!$/
+      (testpath/"index.php").write <<~EOS
+        <?php
+        echo 'Hello world!' . PHP_EOL;
+        var_dump(ldap_connect());
+      EOS
+      main_config = <<~EOS
+        Listen #{port}
+        ServerName localhost:#{port}
+        DocumentRoot "#{testpath}"
+        ErrorLog "#{testpath}/httpd-error.log"
+        ServerRoot "#{Formula["httpd"].opt_prefix}"
+        PidFile "#{testpath}/httpd.pid"
+        LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
+        LoadModule unixd_module lib/httpd/modules/mod_unixd.so
+        LoadModule dir_module lib/httpd/modules/mod_dir.so
+        DirectoryIndex index.php
+      EOS
+
+      php_module = if head?
+        "LoadModule php_module #{lib}/httpd/modules/libphp.so"
+      else
+        "LoadModule php7_module #{lib}/httpd/modules/libphp7.so"
+      end
+
+      (testpath/"httpd.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
+        #{php_module}
+        <FilesMatch \\.(php|phar)$>
+          SetHandler application/x-httpd-php
+        </FilesMatch>
+      EOS
+
+      (testpath/"fpm.conf").write <<~EOS
+        [global]
+        daemonize=no
+        [www]
+        listen = 127.0.0.1:#{port_fpm}
+        pm = dynamic
+        pm.max_children = 5
+        pm.start_servers = 2
+        pm.min_spare_servers = 1
+        pm.max_spare_servers = 3
+      EOS
+
+      (testpath/"httpd-fpm.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
+        LoadModule proxy_module lib/httpd/modules/mod_proxy.so
+        LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
+        </FilesMatch>
+      EOS
+
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+
+      fpm_pid = fork do
+        exec sbin/"php-fpm", "-y", "fpm.conf"
+      end
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd-fpm.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+    ensure
+      if pid
+        Process.kill("TERM", pid)
+        Process.wait(pid)
+      end
+      if fpm_pid
+        Process.kill("TERM", fpm_pid)
+        Process.wait(fpm_pid)
+      end
+    end
+  end
+end
+
+__END__
+diff --git a/build/php.m4 b/build/php.m4
+index 3624a33a8e..d17a635c2c 100644
+--- a/build/php.m4
++++ b/build/php.m4
+@@ -425,7 +425,7 @@ dnl
+ dnl Adds a path to linkpath/runpath (LDFLAGS).
+ dnl
+ AC_DEFUN([PHP_ADD_LIBPATH],[
+-  if test "$1" != "/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     ifelse([$2],,[
+       _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+@@ -470,7 +470,7 @@ dnl
+ dnl Add an include path. If before is 1, add in the beginning of INCLUDES.
+ dnl
+ AC_DEFUN([PHP_ADD_INCLUDE],[
+-  if test "$1" != "/usr/include"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/include"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
+       if test "$2"; then
+diff --git a/configure.ac b/configure.ac
+index 36c6e5e3e2..71b1a16607 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -190,6 +190,14 @@ PHP_ARG_WITH([libdir],
+   [lib],
+   [no])
+
++dnl Support systems with system libraries/includes in e.g. /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk.
++PHP_ARG_WITH([os-sdkpath],
++  [for system SDK directory],
++  [AS_HELP_STRING([--with-os-sdkpath=NAME],
++    [Ignore system libraries and includes in NAME rather than /])],
++  [],
++  [no])
++
+ PHP_ARG_ENABLE([rpath],
+   [whether to enable runpaths],
+   [AS_HELP_STRING([--disable-rpath],

--- a/Formula/php@8.0-debug.rb
+++ b/Formula/php@8.0-debug.rb
@@ -1,0 +1,477 @@
+class PhpAT80Debug < Formula
+  desc "General-purpose scripting language"
+  homepage "https://www.php.net/"
+  # Should only be updated if the new version is announced on the homepage, https://www.php.net/
+  url "https://www.php.net/distributions/php-8.0.21.tar.xz"
+  mirror "https://fossies.org/linux/www/php-8.0.21.tar.xz"
+  sha256 "e87a598f157e0cf0606e64382bb91c8b30c47d4a0fc96b2c17ad547a27869b3b"
+  license "PHP-3.01"
+
+  livecheck do
+    url "https://www.php.net/downloads"
+    regex(/href=.*?php[._-]v?(#{Regexp.escape(version.major_minor)}(?:\.\d+)*)\.t/i)
+  end
+
+  bottle do
+    root_url "https://ghcr.io/v2/shivammathur/php"
+    sha256 arm64_monterey: "6f6681e2de0e1faa000c27ee1f899c5e716a75831dafd575794611269333493a"
+    sha256 arm64_big_sur:  "cdcef041095ccabc806f532386700d266b55a0dfdec5ba0ab812f955f1d80158"
+    sha256 monterey:       "9d408ea8bffa2777f8ff61c15e87eeb821efdade97de549e10620951544d886f"
+    sha256 big_sur:        "c3ec8d8f74fdb074164bcf1cd82a56234a5defd2d6c88880cd6d20be2d552d5b"
+    sha256 catalina:       "4edc18fc677eef16d839c42d99dd4f2522090a01de52f5f85b6b9df297ebe3bf"
+    sha256 x86_64_linux:   "d93ba4aee55c66a53ea5636d02b50b637e4f43cfc6cb190acba9639542fb8cd4"
+  end
+
+  keg_only :versioned_formula
+
+  deprecate! date: "2023-11-26", because: :versioned_formula
+
+  depends_on "httpd" => [:build, :test]
+  depends_on "pkg-config" => :build
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "argon2"
+  depends_on "aspell"
+  depends_on "autoconf"
+  depends_on "curl"
+  depends_on "freetds"
+  depends_on "gd"
+  depends_on "gettext"
+  depends_on "gmp"
+  depends_on "icu4c"
+  depends_on "krb5"
+  depends_on "libpq"
+  depends_on "libsodium"
+  depends_on "libzip"
+  depends_on "oniguruma"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "pcre2"
+  depends_on "sqlite"
+  depends_on "tidy-html5"
+  depends_on "unixodbc"
+
+  uses_from_macos "xz" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "libedit"
+  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
+
+  on_macos do
+    # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/pull/3472
+    patch :DATA
+  end
+
+  def install
+    # buildconf required due to system library linking bug patch
+    system "./buildconf", "--force"
+
+    inreplace "configure" do |s|
+      s.gsub! "APACHE_THREADED_MPM=`$APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes'`",
+              "APACHE_THREADED_MPM="
+      s.gsub! "APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`",
+              "APXS_LIBEXECDIR='$(INSTALL_ROOT)#{lib}/httpd/modules'"
+      s.gsub! "-z `$APXS -q SYSCONFDIR`",
+              "-z ''"
+
+      # apxs will interpolate the @ in the versioned prefix: https://bz.apache.org/bugzilla/show_bug.cgi?id=61944
+      s.gsub! "LIBEXECDIR='$APXS_LIBEXECDIR'",
+              "LIBEXECDIR='" + "#{lib}/httpd/modules".gsub("@", "\\@") + "'"
+    end
+
+    # Update error message in apache sapi to better explain the requirements
+    # of using Apache http in combination with php if the non-compatible MPM
+    # has been selected. Homebrew has chosen not to support being able to
+    # compile a thread safe version of PHP and therefore it is not
+    # possible to recompile as suggested in the original message
+    inreplace "sapi/apache2handler/sapi_apache2.c",
+              "You need to recompile PHP.",
+              "Homebrew PHP does not support a thread-safe php binary. " \
+              "To use the PHP apache sapi please change " \
+              "your httpd config to use the prefork MPM"
+
+    inreplace "sapi/fpm/php-fpm.conf.in", ";daemonize = yes", "daemonize = no"
+
+    config_path = etc/"php/#{version.major_minor}-debug"
+    # Prevent system pear config from inhibiting pear install
+    (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?
+
+    # Prevent homebrew from harcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    # system pkg-config missing
+    ENV["KERBEROS_CFLAGS"] = " "
+    if OS.mac?
+      ENV["SASL_CFLAGS"] = "-I#{MacOS.sdk_path_if_needed}/usr/include/sasl"
+      ENV["SASL_LIBS"] = "-lsasl2"
+    end
+    if OS.linux?
+      ENV["SQLITE_CFLAGS"] = "-I#{Formula["sqlite"].opt_include}"
+      ENV["SQLITE_LIBS"] = "-lsqlite3"
+      ENV["BZIP_DIR"] = Formula["bzip2"].opt_prefix
+    end
+
+    # Each extension that is built on Mojave needs a direct reference to the
+    # sdk path or it won't find the headers
+    headers_path = ""
+    headers_path = "=#{MacOS.sdk_path_if_needed}/usr" if OS.mac?
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --with-pear=#{pkgshare}/pear
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-debug
+      --enable-exif
+      --enable-ftp
+      --enable-fpm
+      --enable-gd
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-phpdbg-readline
+      --enable-phpdbg-webhelper
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --with-apxs2=#{Formula["httpd"].opt_bin}/apxs
+      --with-bz2#{headers_path}
+      --with-curl
+      --with-external-gd
+      --with-external-pcre
+      --with-ffi
+      --with-fpm-user=_www
+      --with-fpm-group=_www
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-iconv#{headers_path}
+      --with-kerberos
+      --with-layout=GNU
+      --with-ldap=#{Formula["openldap"].opt_prefix}
+      --with-libxml
+      --with-libedit
+      --with-mhash#{headers_path}
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-ndbm#{headers_path}
+      --with-openssl
+      --with-password-argon2=#{Formula["argon2"].opt_prefix}
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pdo-sqlite
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sodium
+      --with-sqlite3
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
+      --with-unixODBC
+      --with-xsl
+      --with-zip
+      --with-zlib
+    ]
+
+    if OS.mac?
+      args << "--enable-dtrace"
+      args << "--with-ldap-sasl"
+      args << "--with-os-sdkpath=#{MacOS.sdk_path_if_needed}"
+    end
+    if OS.linux?
+      args << "--disable-dtrace"
+      args << "--without-ldap-sasl"
+      args << "--without-ndbm"
+      args << "--without-gdbm"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", %r{; ?extension_dir = "\./"},
+        "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+    end
+
+    # Use OpenSSL cert bundle
+    openssl = Formula["openssl@1.1"]
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", /; ?openssl\.cafile=/,
+        "openssl.cafile = \"#{openssl.pkgetc}/cert.pem\""
+      inreplace "php.ini-#{mode}", /; ?openssl\.capath=/,
+        "openssl.capath = \"#{openssl.pkgetc}/certs\""
+    end
+
+    config_files = {
+      "php.ini-development"   => "php.ini",
+      "php.ini-production"    => "php.ini-production",
+      "sapi/fpm/php-fpm.conf" => "php-fpm.conf",
+      "sapi/fpm/www.conf"     => "php-fpm.d/www.conf",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+
+    unless (var/"log/php-fpm.log").exist?
+      (var/"log").mkpath
+      touch var/"log/php-fpm.log"
+    end
+  end
+
+  def post_install
+    pear_prefix = pkgshare/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    pecl_path.mkpath
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear@#{version.major_minor}-debug"
+    cp_r pkgshare/"pear/.", pear_path
+    {
+      "php_ini"  => etc/"php/#{version.major_minor}-debug/php.ini",
+      "php_dir"  => pear_path,
+      "doc_dir"  => pear_path/"doc",
+      "ext_dir"  => pecl_path/php_basename,
+      "bin_dir"  => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir"  => pear_path/"cfg",
+      "www_dir"  => pear_path/"htdocs",
+      "man_dir"  => HOMEBREW_PREFIX/"share/man",
+      "test_dir" => pear_path/"test",
+      "php_bin"  => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if /(?<!bin|man)_dir$/.match?(key)
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    system bin/"pear", "update-channels"
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{version.major_minor}-debug/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def caveats
+    <<~EOS
+      To enable PHP in Apache add the following to httpd.conf and restart Apache:
+          LoadModule php_module #{opt_lib}/httpd/modules/libphp.so
+
+          <FilesMatch \\.php$>
+              SetHandler application/x-httpd-php
+          </FilesMatch>
+
+      Finally, check DirectoryIndex includes index.php
+          DirectoryIndex index.php index.html
+
+      The php.ini and php-fpm.ini file can be found in:
+          #{etc}/php/#{version.major_minor}-debug/
+    EOS
+  end
+
+  plist_options manual: "php-fpm"
+  service do
+    run [opt_sbin/"php-fpm", "--nodaemonize"]
+    run_type :immediate
+    keep_alive true
+    error_log_path var/"log/php-fpm.log"
+    working_dir var
+  end
+
+  test do
+    assert_match(/^Zend OPcache$/, shell_output("#{bin}/php -i"),
+      "Zend OPCache extension not loaded")
+    # Test related to libxml2 and
+    # https://github.com/Homebrew/homebrew-core/issues/28398
+    if OS.mac?
+      assert_includes MachO::Tools.dylibs("#{bin}/php"),
+              "#{Formula["libpq"].opt_lib}/libpq.5.dylib"
+    end
+
+    system "#{sbin}/php-fpm", "-t"
+    system "#{bin}/phpdbg", "-V"
+    system "#{bin}/php-cgi", "-m"
+    # Prevent SNMP extension to be added
+    refute_match(/^snmp$/, shell_output("#{bin}/php -m"),
+      "SNMP extension doesn't work reliably with Homebrew on High Sierra")
+    begin
+      port = free_port
+      port_fpm = free_port
+
+      expected_output = /^Hello world!$/
+      (testpath/"index.php").write <<~EOS
+        <?php
+        echo 'Hello world!' . PHP_EOL;
+        var_dump(ldap_connect());
+      EOS
+      main_config = <<~EOS
+        Listen #{port}
+        ServerName localhost:#{port}
+        DocumentRoot "#{testpath}"
+        ErrorLog "#{testpath}/httpd-error.log"
+        ServerRoot "#{Formula["httpd"].opt_prefix}"
+        PidFile "#{testpath}/httpd.pid"
+        LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
+        LoadModule unixd_module lib/httpd/modules/mod_unixd.so
+        LoadModule dir_module lib/httpd/modules/mod_dir.so
+        DirectoryIndex index.php
+      EOS
+
+      (testpath/"httpd.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
+        LoadModule php_module #{lib}/httpd/modules/libphp.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler application/x-httpd-php
+        </FilesMatch>
+      EOS
+
+      (testpath/"fpm.conf").write <<~EOS
+        [global]
+        daemonize=no
+        [www]
+        listen = 127.0.0.1:#{port_fpm}
+        pm = dynamic
+        pm.max_children = 5
+        pm.start_servers = 2
+        pm.min_spare_servers = 1
+        pm.max_spare_servers = 3
+      EOS
+
+      (testpath/"httpd-fpm.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
+        LoadModule proxy_module lib/httpd/modules/mod_proxy.so
+        LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
+        </FilesMatch>
+      EOS
+
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+
+      fpm_pid = fork do
+        exec sbin/"php-fpm", "-y", "fpm.conf"
+      end
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd-fpm.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+    ensure
+      if pid
+        Process.kill("TERM", pid)
+        Process.wait(pid)
+      end
+      if fpm_pid
+        Process.kill("TERM", fpm_pid)
+        Process.wait(fpm_pid)
+      end
+    end
+  end
+end
+
+__END__
+diff --git a/build/php.m4 b/build/php.m4
+index 3624a33a8e..d17a635c2c 100644
+--- a/build/php.m4
++++ b/build/php.m4
+@@ -425,7 +425,7 @@ dnl
+ dnl Adds a path to linkpath/runpath (LDFLAGS).
+ dnl
+ AC_DEFUN([PHP_ADD_LIBPATH],[
+-  if test "$1" != "/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     ifelse([$2],,[
+       _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+@@ -470,7 +470,7 @@ dnl
+ dnl Add an include path. If before is 1, add in the beginning of INCLUDES.
+ dnl
+ AC_DEFUN([PHP_ADD_INCLUDE],[
+-  if test "$1" != "/usr/include"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/include"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
+       if test "$2"; then
+diff --git a/configure.ac b/configure.ac
+index 36c6e5e3e2..71b1a16607 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -190,6 +190,14 @@ PHP_ARG_WITH([libdir],
+   [lib],
+   [no])
+
++dnl Support systems with system libraries/includes in e.g. /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk.
++PHP_ARG_WITH([os-sdkpath],
++  [for system SDK directory],
++  [AS_HELP_STRING([--with-os-sdkpath=NAME],
++    [Ignore system libraries and includes in NAME rather than /])],
++  [],
++  [no])
++
+ PHP_ARG_ENABLE([rpath],
+   [whether to enable runpaths],
+   [AS_HELP_STRING([--disable-rpath],

--- a/Formula/php@8.1-debug.rb
+++ b/Formula/php@8.1-debug.rb
@@ -23,7 +23,7 @@ class PhpAT81Debug < Formula
   end
 
   head do
-    url "https://github.com/php/php-src.git"
+    url "https://github.com/php/php-src.git", branch: "master"
 
     depends_on "bison" => :build # bison >= 3.0.0 required to generate parsers
     depends_on "re2c" => :build # required to generate PHP lexers

--- a/Formula/php@8.1-debug.rb
+++ b/Formula/php@8.1-debug.rb
@@ -1,0 +1,477 @@
+class PhpAT81Debug < Formula
+  desc "General-purpose scripting language"
+  homepage "https://www.php.net/"
+  # Should only be updated if the new version is announced on the homepage, https://www.php.net/
+  url "https://www.php.net/distributions/php-8.1.8.tar.xz"
+  mirror "https://fossies.org/linux/www/php-8.1.8.tar.xz"
+  sha256 "04c065515bc347bc68e0bb1ac7182669a98a731e4a17727e5731650ad3d8de4c"
+  license "PHP-3.01"
+
+  livecheck do
+    url "https://www.php.net/downloads"
+    regex(/href=.*?php[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  bottle do
+    root_url "https://ghcr.io/v2/shivammathur/php"
+    sha256 arm64_monterey: "1c09c1e2a8e8f27eeec9403f2a592a1c4618f86f2fb8eb8470e03c84c1274233"
+    sha256 arm64_big_sur:  "e2af3359406cc645f6933ff6826f89361d0caf64bf7b9d93bb75c93d831b5086"
+    sha256 monterey:       "f4841c04890f7126517ec2b3f307237a12235f0606eb2de4236ce260255f8e9c"
+    sha256 big_sur:        "3027462eb040dbd3289d80daade000527b4ccd80da45c6f8c5bd6ca0987f80f8"
+    sha256 catalina:       "6eb5639f31f7487f2ef6549123e8e768c2b06af3b321be4789640bfe5309baa9"
+    sha256 x86_64_linux:   "be9c2ce7c1c0cffcd37e3e70870cb2a5c832ecae22a64018cbbb765ae37d31a5"
+  end
+
+  head do
+    url "https://github.com/php/php-src.git"
+
+    depends_on "bison" => :build # bison >= 3.0.0 required to generate parsers
+    depends_on "re2c" => :build # required to generate PHP lexers
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "httpd" => [:build, :test]
+  depends_on "pkg-config" => :build
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "argon2"
+  depends_on "aspell"
+  depends_on "autoconf"
+  depends_on "curl"
+  depends_on "freetds"
+  depends_on "gd"
+  depends_on "gettext"
+  depends_on "gmp"
+  depends_on "icu4c"
+  depends_on "krb5"
+  depends_on "libpq"
+  depends_on "libsodium"
+  depends_on "libzip"
+  depends_on "oniguruma"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "pcre2"
+  depends_on "sqlite"
+  depends_on "tidy-html5"
+  depends_on "unixodbc"
+
+  uses_from_macos "xz" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "libedit"
+  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
+
+  on_macos do
+    # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/pull/3472
+    patch :DATA
+  end
+
+  def install
+    # buildconf required due to system library linking bug patch
+    system "./buildconf", "--force"
+
+    inreplace "configure" do |s|
+      s.gsub! "APACHE_THREADED_MPM=`$APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes'`",
+              "APACHE_THREADED_MPM="
+      s.gsub! "APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`",
+              "APXS_LIBEXECDIR='$(INSTALL_ROOT)#{lib}/httpd/modules'"
+      s.gsub! "-z `$APXS -q SYSCONFDIR`",
+              "-z ''"
+    end
+
+    # Update error message in apache sapi to better explain the requirements
+    # of using Apache http in combination with php if the non-compatible MPM
+    # has been selected. Homebrew has chosen not to support being able to
+    # compile a thread safe version of PHP and therefore it is not
+    # possible to recompile as suggested in the original message
+    inreplace "sapi/apache2handler/sapi_apache2.c",
+              "You need to recompile PHP.",
+              "Homebrew PHP does not support a thread-safe php binary. " \
+              "To use the PHP apache sapi please change " \
+              "your httpd config to use the prefork MPM"
+
+    inreplace "sapi/fpm/php-fpm.conf.in", ";daemonize = yes", "daemonize = no"
+
+    config_path = etc/"php/#{version.major_minor}-debug"
+    # Prevent system pear config from inhibiting pear install
+    (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?
+
+    # Prevent homebrew from harcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    # system pkg-config missing
+    ENV["KERBEROS_CFLAGS"] = " "
+    if OS.mac?
+      ENV["SASL_CFLAGS"] = "-I#{MacOS.sdk_path_if_needed}/usr/include/sasl"
+      ENV["SASL_LIBS"] = "-lsasl2"
+    end
+    if OS.linux?
+      ENV["SQLITE_CFLAGS"] = "-I#{Formula["sqlite"].opt_include}"
+      ENV["SQLITE_LIBS"] = "-lsqlite3"
+      ENV["BZIP_DIR"] = Formula["bzip2"].opt_prefix
+    end
+
+    # Each extension that is built on Mojave needs a direct reference to the
+    # sdk path or it won't find the headers
+    headers_path = ""
+    headers_path = "=#{MacOS.sdk_path_if_needed}/usr" if OS.mac?
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --with-pear=#{pkgshare}/pear
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-debug
+      --enable-exif
+      --enable-ftp
+      --enable-fpm
+      --enable-gd
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-phpdbg-readline
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --with-apxs2=#{Formula["httpd"].opt_bin}/apxs
+      --with-bz2#{headers_path}
+      --with-curl
+      --with-external-gd
+      --with-external-pcre
+      --with-ffi
+      --with-fpm-user=_www
+      --with-fpm-group=_www
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-iconv#{headers_path}
+      --with-kerberos
+      --with-layout=GNU
+      --with-ldap=#{Formula["openldap"].opt_prefix}
+      --with-libxml
+      --with-libedit
+      --with-mhash#{headers_path}
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-ndbm#{headers_path}
+      --with-openssl
+      --with-password-argon2=#{Formula["argon2"].opt_prefix}
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pdo-sqlite
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sodium
+      --with-sqlite3
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
+      --with-unixODBC
+      --with-xsl
+      --with-zip
+      --with-zlib
+    ]
+
+    if OS.mac?
+      args << "--enable-dtrace"
+      args << "--with-ldap-sasl"
+      args << "--with-os-sdkpath=#{MacOS.sdk_path_if_needed}"
+    end
+    if OS.linux?
+      args << "--disable-dtrace"
+      args << "--without-ldap-sasl"
+      args << "--without-ndbm"
+      args << "--without-gdbm"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", %r{; ?extension_dir = "\./"},
+        "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+    end
+
+    # Use OpenSSL cert bundle
+    openssl = Formula["openssl@1.1"]
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", /; ?openssl\.cafile=/,
+        "openssl.cafile = \"#{openssl.pkgetc}/cert.pem\""
+      inreplace "php.ini-#{mode}", /; ?openssl\.capath=/,
+        "openssl.capath = \"#{openssl.pkgetc}/certs\""
+    end
+
+    config_files = {
+      "php.ini-development"   => "php.ini",
+      "php.ini-production"    => "php.ini-production",
+      "sapi/fpm/php-fpm.conf" => "php-fpm.conf",
+      "sapi/fpm/www.conf"     => "php-fpm.d/www.conf",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+
+    unless (var/"log/php-fpm.log").exist?
+      (var/"log").mkpath
+      touch var/"log/php-fpm.log"
+    end
+  end
+
+  def post_install
+    pear_prefix = pkgshare/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    pecl_path.mkpath
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear"
+    cp_r pkgshare/"pear/.", pear_path
+    {
+      "php_ini"  => etc/"php/#{version.major_minor}-debug/php.ini",
+      "php_dir"  => pear_path,
+      "doc_dir"  => pear_path/"doc",
+      "ext_dir"  => pecl_path/php_basename,
+      "bin_dir"  => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir"  => pear_path/"cfg",
+      "www_dir"  => pear_path/"htdocs",
+      "man_dir"  => HOMEBREW_PREFIX/"share/man",
+      "test_dir" => pear_path/"test",
+      "php_bin"  => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if /(?<!bin|man)_dir$/.match?(key)
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    system bin/"pear", "update-channels"
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{version.major_minor}-debug/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def caveats
+    <<~EOS
+      To enable PHP in Apache add the following to httpd.conf and restart Apache:
+          LoadModule php_module #{opt_lib}/httpd/modules/libphp.so
+
+          <FilesMatch \\.php$>
+              SetHandler application/x-httpd-php
+          </FilesMatch>
+
+      Finally, check DirectoryIndex includes index.php
+          DirectoryIndex index.php index.html
+
+      The php.ini and php-fpm.ini file can be found in:
+          #{etc}/php/#{version.major_minor}-debug/
+    EOS
+  end
+
+  plist_options manual: "php-fpm"
+  service do
+    run [opt_sbin/"php-fpm", "--nodaemonize"]
+    run_type :immediate
+    keep_alive true
+    error_log_path var/"log/php-fpm.log"
+    working_dir var
+  end
+
+  test do
+    assert_match(/^Zend OPcache$/, shell_output("#{bin}/php -i"),
+      "Zend OPCache extension not loaded")
+    # Test related to libxml2 and
+    # https://github.com/Homebrew/homebrew-core/issues/28398
+    if OS.mac?
+      assert_includes MachO::Tools.dylibs("#{bin}/php"),
+              "#{Formula["libpq"].opt_lib}/libpq.5.dylib"
+    end
+
+    system "#{sbin}/php-fpm", "-t"
+    system "#{bin}/phpdbg", "-V"
+    system "#{bin}/php-cgi", "-m"
+    # Prevent SNMP extension to be added
+    refute_match(/^snmp$/, shell_output("#{bin}/php -m"),
+      "SNMP extension doesn't work reliably with Homebrew on High Sierra")
+    begin
+      port = free_port
+      port_fpm = free_port
+
+      expected_output = /^Hello world!$/
+      (testpath/"index.php").write <<~EOS
+        <?php
+        echo 'Hello world!' . PHP_EOL;
+        var_dump(ldap_connect());
+      EOS
+      main_config = <<~EOS
+        Listen #{port}
+        ServerName localhost:#{port}
+        DocumentRoot "#{testpath}"
+        ErrorLog "#{testpath}/httpd-error.log"
+        ServerRoot "#{Formula["httpd"].opt_prefix}"
+        PidFile "#{testpath}/httpd.pid"
+        LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
+        LoadModule unixd_module lib/httpd/modules/mod_unixd.so
+        LoadModule dir_module lib/httpd/modules/mod_dir.so
+        DirectoryIndex index.php
+      EOS
+
+      (testpath/"httpd.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
+        LoadModule php_module #{lib}/httpd/modules/libphp.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler application/x-httpd-php
+        </FilesMatch>
+      EOS
+
+      (testpath/"fpm.conf").write <<~EOS
+        [global]
+        daemonize=no
+        [www]
+        listen = 127.0.0.1:#{port_fpm}
+        pm = dynamic
+        pm.max_children = 5
+        pm.start_servers = 2
+        pm.min_spare_servers = 1
+        pm.max_spare_servers = 3
+      EOS
+
+      (testpath/"httpd-fpm.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
+        LoadModule proxy_module lib/httpd/modules/mod_proxy.so
+        LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
+        </FilesMatch>
+      EOS
+
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+
+      fpm_pid = fork do
+        exec sbin/"php-fpm", "-y", "fpm.conf"
+      end
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd-fpm.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+    ensure
+      if pid
+        Process.kill("TERM", pid)
+        Process.wait(pid)
+      end
+      if fpm_pid
+        Process.kill("TERM", fpm_pid)
+        Process.wait(fpm_pid)
+      end
+    end
+  end
+end
+
+__END__
+diff --git a/build/php.m4 b/build/php.m4
+index 3624a33a8e..d17a635c2c 100644
+--- a/build/php.m4
++++ b/build/php.m4
+@@ -425,7 +425,7 @@ dnl
+ dnl Adds a path to linkpath/runpath (LDFLAGS).
+ dnl
+ AC_DEFUN([PHP_ADD_LIBPATH],[
+-  if test "$1" != "/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     ifelse([$2],,[
+       _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+@@ -470,7 +470,7 @@ dnl
+ dnl Add an include path. If before is 1, add in the beginning of INCLUDES.
+ dnl
+ AC_DEFUN([PHP_ADD_INCLUDE],[
+-  if test "$1" != "/usr/include"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/include"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
+       if test "$2"; then
+diff --git a/configure.ac b/configure.ac
+index 36c6e5e3e2..71b1a16607 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -190,6 +190,14 @@ PHP_ARG_WITH([libdir],
+   [lib],
+   [no])
+
++dnl Support systems with system libraries/includes in e.g. /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk.
++PHP_ARG_WITH([os-sdkpath],
++  [for system SDK directory],
++  [AS_HELP_STRING([--with-os-sdkpath=NAME],
++    [Ignore system libraries and includes in NAME rather than /])],
++  [],
++  [no])
++
+ PHP_ARG_ENABLE([rpath],
+   [whether to enable runpaths],
+   [AS_HELP_STRING([--disable-rpath],

--- a/Formula/php@8.2-debug.rb
+++ b/Formula/php@8.2-debug.rb
@@ -1,0 +1,483 @@
+class PhpAT82Debug < Formula
+  desc "General-purpose scripting language"
+  homepage "https://www.php.net/"
+  url "https://github.com/php/php-src/archive/53e71415154f9141dc5f3e894ed215159d366b1e.tar.gz?commit=53e71415154f9141dc5f3e894ed215159d366b1e"
+  version "8.2.0"
+  sha256 "cb66a174e5f9194d39a2313ab4f03cb8e458149c74be69de69c48c91403e4b89"
+  license "PHP-3.01"
+  revision 3
+
+  bottle do
+    root_url "https://ghcr.io/v2/shivammathur/php"
+    rebuild 212
+    sha256 arm64_monterey: "04d41f3d99e9a78afa69ae22fcd74abd1addb48071bb0ed66f853caf1a285187"
+    sha256 arm64_big_sur:  "e5a96bcf38161393453549f0fc4770180cddefb94c277b212a4f1c18d5cd5406"
+    sha256 monterey:       "21ee34b0eb70d4acb510fd917e4d623af277ca5e2bfa7cf9bc5255dc3cfb5586"
+    sha256 big_sur:        "8d1868cc0d58c19849897af641fa73f1f6875889d2e616ccb7a97dff4dd8e802"
+    sha256 catalina:       "a66d50a176cea34da4b82e0067ce52493680ab3d328ae8892852c89a5c533981"
+    sha256 x86_64_linux:   "51cb5068cf91e262ca0b7893a668c0b46e19fbcf90be971a40d603ca01564a4b"
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "bison" => :build
+  depends_on "httpd" => [:build, :test]
+  depends_on "pkg-config" => :build
+  depends_on "re2c" => :build
+  depends_on "apr"
+  depends_on "apr-util"
+  depends_on "argon2"
+  depends_on "aspell"
+  depends_on "autoconf"
+  depends_on "curl"
+  depends_on "freetds"
+  depends_on "gd"
+  depends_on "gettext"
+  depends_on "gmp"
+  depends_on "icu4c"
+  depends_on "krb5"
+  depends_on "libpq"
+  depends_on "libsodium"
+  depends_on "libzip"
+  depends_on "oniguruma"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "pcre2"
+  depends_on "sqlite"
+  depends_on "tidy-html5"
+  depends_on "unixodbc"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "libedit"
+  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "zlib"
+
+  on_macos do
+    # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/pull/3472
+    patch :DATA
+  end
+
+  def install
+    # buildconf required due to system library linking bug patch
+    system "./buildconf", "--force"
+
+    inreplace "configure" do |s|
+      s.gsub! "APACHE_THREADED_MPM=`$APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes'`",
+              "APACHE_THREADED_MPM="
+      s.gsub! "APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`",
+              "APXS_LIBEXECDIR='$(INSTALL_ROOT)#{lib}/httpd/modules'"
+      s.gsub! "-z `$APXS -q SYSCONFDIR`",
+              "-z ''"
+
+      # apxs will interpolate the @ in the versioned prefix: https://bz.apache.org/bugzilla/show_bug.cgi?id=61944
+      s.gsub! "LIBEXECDIR='$APXS_LIBEXECDIR'",
+              "LIBEXECDIR='" + "#{lib}/httpd/modules".gsub("@", "\\@") + "'"
+    end
+
+    # Update error message in apache sapi to better explain the requirements
+    # of using Apache http in combination with php if the non-compatible MPM
+    # has been selected. Homebrew has chosen not to support being able to
+    # compile a thread safe version of PHP and therefore it is not
+    # possible to recompile as suggested in the original message
+    inreplace "sapi/apache2handler/sapi_apache2.c",
+              "You need to recompile PHP.",
+              "Homebrew PHP does not support a thread-safe php binary. " \
+              "To use the PHP apache sapi please change " \
+              "your httpd config to use the prefork MPM"
+
+    inreplace "sapi/fpm/php-fpm.conf.in", ";daemonize = yes", "daemonize = no"
+
+    config_path = etc/"php/#{php_version}"
+    # Prevent system pear config from inhibiting pear install
+    (config_path/"pear.conf").delete if (config_path/"pear.conf").exist?
+
+    # Prevent homebrew from harcoding path to sed shim in phpize script
+    ENV["lt_cv_path_SED"] = "sed"
+
+    # system pkg-config missing
+    ENV["KERBEROS_CFLAGS"] = " "
+    if OS.mac?
+      ENV["SASL_CFLAGS"] = "-I#{MacOS.sdk_path_if_needed}/usr/include/sasl"
+      ENV["SASL_LIBS"] = "-lsasl2"
+    end
+    if OS.linux?
+      ENV["SQLITE_CFLAGS"] = "-I#{Formula["sqlite"].opt_include}"
+      ENV["SQLITE_LIBS"] = "-lsqlite3"
+      ENV["BZIP_DIR"] = Formula["bzip2"].opt_prefix
+    end
+
+    # Each extension that is built on Mojave needs a direct reference to the
+    # sdk path or it won't find the headers
+    headers_path = ""
+    headers_path = "=#{MacOS.sdk_path_if_needed}/usr" if OS.mac?
+
+    args = %W[
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{config_path}
+      --with-config-file-path=#{config_path}
+      --with-config-file-scan-dir=#{config_path}/conf.d
+      --with-pear=#{pkgshare}/pear
+      --enable-bcmath
+      --enable-calendar
+      --enable-dba
+      --enable-debug
+      --enable-exif
+      --enable-ftp
+      --enable-fpm
+      --enable-gd
+      --enable-intl
+      --enable-mbregex
+      --enable-mbstring
+      --enable-mysqlnd
+      --enable-opcache
+      --enable-pcntl
+      --enable-phpdbg
+      --enable-phpdbg-readline
+      --enable-phpdbg-webhelper
+      --enable-shmop
+      --enable-soap
+      --enable-sockets
+      --enable-sysvmsg
+      --enable-sysvsem
+      --enable-sysvshm
+      --with-apxs2=#{Formula["httpd"].opt_bin}/apxs
+      --with-bz2#{headers_path}
+      --with-curl
+      --with-external-gd
+      --with-external-pcre
+      --with-ffi
+      --with-fpm-user=_www
+      --with-fpm-group=_www
+      --with-gettext=#{Formula["gettext"].opt_prefix}
+      --with-gmp=#{Formula["gmp"].opt_prefix}
+      --with-iconv#{headers_path}
+      --with-kerberos
+      --with-layout=GNU
+      --with-ldap=#{Formula["openldap"].opt_prefix}
+      --with-libxml
+      --with-libedit
+      --with-mhash#{headers_path}
+      --with-mysql-sock=/tmp/mysql.sock
+      --with-mysqli=mysqlnd
+      --with-ndbm#{headers_path}
+      --with-openssl
+      --with-password-argon2
+      --with-pdo-dblib=#{Formula["freetds"].opt_prefix}
+      --with-pdo-mysql=mysqlnd
+      --with-pdo-odbc=unixODBC,#{Formula["unixodbc"].opt_prefix}
+      --with-pdo-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pdo-sqlite
+      --with-pgsql=#{Formula["libpq"].opt_prefix}
+      --with-pic
+      --with-pspell=#{Formula["aspell"].opt_prefix}
+      --with-sodium
+      --with-sqlite3
+      --with-tidy=#{Formula["tidy-html5"].opt_prefix}
+      --with-unixODBC
+      --with-xsl
+      --with-zip
+      --with-zlib
+    ]
+
+    if OS.mac?
+      args << "--enable-dtrace"
+      args << "--with-ldap-sasl"
+      args << "--with-os-sdkpath=#{MacOS.sdk_path_if_needed}"
+    end
+    if OS.linux?
+      args << "--disable-dtrace"
+      args << "--without-ldap-sasl"
+      args << "--without-ndbm"
+      args << "--without-gdbm"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Allow pecl to install outside of Cellar
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    orig_ext_dir = File.basename(extension_dir)
+    inreplace bin/"php-config", lib/"php", prefix/"pecl"
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", %r{; ?extension_dir = "\./"},
+        "extension_dir = \"#{HOMEBREW_PREFIX}/lib/php/pecl/#{orig_ext_dir}\""
+    end
+
+    # Use OpenSSL cert bundle
+    openssl = Formula["openssl@1.1"]
+    %w[development production].each do |mode|
+      inreplace "php.ini-#{mode}", /; ?openssl\.cafile=/,
+        "openssl.cafile = \"#{openssl.pkgetc}/cert.pem\""
+      inreplace "php.ini-#{mode}", /; ?openssl\.capath=/,
+        "openssl.capath = \"#{openssl.pkgetc}/certs\""
+    end
+
+    config_files = {
+      "php.ini-development"   => "php.ini",
+      "php.ini-production"    => "php.ini-production",
+      "sapi/fpm/php-fpm.conf" => "php-fpm.conf",
+      "sapi/fpm/www.conf"     => "php-fpm.d/www.conf",
+    }
+    config_files.each_value do |dst|
+      dst_default = config_path/"#{dst}.default"
+      rm dst_default if dst_default.exist?
+    end
+    config_path.install config_files
+
+    unless (var/"log/php-fpm.log").exist?
+      (var/"log").mkpath
+      touch var/"log/php-fpm.log"
+    end
+  end
+
+  def post_install
+    pear_prefix = pkgshare/"pear"
+    pear_files = %W[
+      #{pear_prefix}/.depdblock
+      #{pear_prefix}/.filemap
+      #{pear_prefix}/.depdb
+      #{pear_prefix}/.lock
+    ]
+
+    %W[
+      #{pear_prefix}/.channels
+      #{pear_prefix}/.channels/.alias
+    ].each do |f|
+      chmod 0755, f
+      pear_files.concat(Dir["#{f}/*"])
+    end
+
+    chmod 0644, pear_files
+
+    # Custom location for extensions installed via pecl
+    pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
+    pecl_path.mkpath
+    ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
+    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    php_basename = File.basename(extension_dir)
+    php_ext_dir = opt_prefix/"lib/php"/php_basename
+
+    # fix pear config to install outside cellar
+    pear_path = HOMEBREW_PREFIX/"share/pear@#{php_version}"
+    cp_r pkgshare/"pear/.", pear_path
+    {
+      "php_ini"  => etc/"php/#{php_version}/php.ini",
+      "php_dir"  => pear_path,
+      "doc_dir"  => pear_path/"doc",
+      "ext_dir"  => pecl_path/php_basename,
+      "bin_dir"  => opt_bin,
+      "data_dir" => pear_path/"data",
+      "cfg_dir"  => pear_path/"cfg",
+      "www_dir"  => pear_path/"htdocs",
+      "man_dir"  => HOMEBREW_PREFIX/"share/man",
+      "test_dir" => pear_path/"test",
+      "php_bin"  => opt_bin/"php",
+    }.each do |key, value|
+      value.mkpath if /(?<!bin|man)_dir$/.match?(key)
+      system bin/"pear", "config-set", key, value, "system"
+    end
+
+    system bin/"pear", "update-channels"
+
+    %w[
+      opcache
+    ].each do |e|
+      ext_config_path = etc/"php/#{php_version}/conf.d/ext-#{e}.ini"
+      extension_type = (e == "opcache") ? "zend_extension" : "extension"
+      if ext_config_path.exist?
+        inreplace ext_config_path,
+          /#{extension_type}=.*$/, "#{extension_type}=#{php_ext_dir}/#{e}.so"
+      else
+        ext_config_path.write <<~EOS
+          [#{e}]
+          #{extension_type}="#{php_ext_dir}/#{e}.so"
+        EOS
+      end
+    end
+  end
+
+  def caveats
+    <<~EOS
+      To enable PHP in Apache add the following to httpd.conf and restart Apache:
+          LoadModule php_module #{opt_lib}/httpd/modules/libphp.so
+
+          <FilesMatch \\.php$>
+              SetHandler application/x-httpd-php
+          </FilesMatch>
+
+      Finally, check DirectoryIndex includes index.php
+          DirectoryIndex index.php index.html
+
+      The php.ini and php-fpm.ini file can be found in:
+          #{etc}/php/#{php_version}/
+    EOS
+  end
+
+  def php_version
+    version.to_s.split(".")[0..1].join(".") + "-debug"
+  end
+
+  plist_options manual: "php-fpm"
+  service do
+    run [opt_sbin/"php-fpm", "--nodaemonize"]
+    run_type :immediate
+    keep_alive true
+    error_log_path var/"log/php-fpm.log"
+    working_dir var
+  end
+
+  test do
+    assert_match(/^Zend OPcache$/, shell_output("#{bin}/php -i"),
+      "Zend OPCache extension not loaded")
+    # Test related to libxml2 and
+    # https://github.com/Homebrew/homebrew-core/issues/28398
+    if OS.mac?
+      assert_includes MachO::Tools.dylibs("#{bin}/php"),
+              "#{Formula["libpq"].opt_lib}/libpq.5.dylib"
+    end
+
+    system "#{sbin}/php-fpm", "-t"
+    system "#{bin}/phpdbg", "-V"
+    system "#{bin}/php-cgi", "-m"
+    # Prevent SNMP extension to be added
+    refute_match(/^snmp$/, shell_output("#{bin}/php -m"),
+      "SNMP extension doesn't work reliably with Homebrew on High Sierra")
+    begin
+      require "socket"
+
+      server = TCPServer.new(0)
+      port = server.addr[1]
+      server_fpm = TCPServer.new(0)
+      port_fpm = server_fpm.addr[1]
+      server.close
+      server_fpm.close
+
+      expected_output = /^Hello world!$/
+      (testpath/"index.php").write <<~EOS
+        <?php
+        echo 'Hello world!' . PHP_EOL;
+        var_dump(ldap_connect());
+      EOS
+      main_config = <<~EOS
+        Listen #{port}
+        ServerName localhost:#{port}
+        DocumentRoot "#{testpath}"
+        ErrorLog "#{testpath}/httpd-error.log"
+        ServerRoot "#{Formula["httpd"].opt_prefix}"
+        PidFile "#{testpath}/httpd.pid"
+        LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
+        LoadModule unixd_module lib/httpd/modules/mod_unixd.so
+        LoadModule dir_module lib/httpd/modules/mod_dir.so
+        DirectoryIndex index.php
+      EOS
+
+      (testpath/"httpd.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_prefork_module lib/httpd/modules/mod_mpm_prefork.so
+        LoadModule php_module #{lib}/httpd/modules/libphp.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler application/x-httpd-php
+        </FilesMatch>
+      EOS
+
+      (testpath/"fpm.conf").write <<~EOS
+        [global]
+        daemonize=no
+        [www]
+        listen = 127.0.0.1:#{port_fpm}
+        pm = dynamic
+        pm.max_children = 5
+        pm.start_servers = 2
+        pm.min_spare_servers = 1
+        pm.max_spare_servers = 3
+      EOS
+
+      (testpath/"httpd-fpm.conf").write <<~EOS
+        #{main_config}
+        LoadModule mpm_event_module lib/httpd/modules/mod_mpm_event.so
+        LoadModule proxy_module lib/httpd/modules/mod_proxy.so
+        LoadModule proxy_fcgi_module lib/httpd/modules/mod_proxy_fcgi.so
+        <FilesMatch \\.(php|phar)$>
+          SetHandler "proxy:fcgi://127.0.0.1:#{port_fpm}"
+        </FilesMatch>
+      EOS
+
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+
+      fpm_pid = fork do
+        exec sbin/"php-fpm", "-y", "fpm.conf"
+      end
+      pid = fork do
+        exec Formula["httpd"].opt_bin/"httpd", "-X", "-f", "#{testpath}/httpd-fpm.conf"
+      end
+      sleep 3
+
+      assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+    ensure
+      if pid
+        Process.kill("TERM", pid)
+        Process.wait(pid)
+      end
+      if fpm_pid
+        Process.kill("TERM", fpm_pid)
+        Process.wait(fpm_pid)
+      end
+    end
+  end
+end
+
+__END__
+diff --git a/build/php.m4 b/build/php.m4
+index 3624a33a8e..d17a635c2c 100644
+--- a/build/php.m4
++++ b/build/php.m4
+@@ -425,7 +425,7 @@ dnl
+ dnl Adds a path to linkpath/runpath (LDFLAGS).
+ dnl
+ AC_DEFUN([PHP_ADD_LIBPATH],[
+-  if test "$1" != "/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/$PHP_LIBDIR" && test "$1" != "/usr/lib"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     ifelse([$2],,[
+       _PHP_ADD_LIBPATH_GLOBAL([$ai_p])
+@@ -470,7 +470,7 @@ dnl
+ dnl Add an include path. If before is 1, add in the beginning of INCLUDES.
+ dnl
+ AC_DEFUN([PHP_ADD_INCLUDE],[
+-  if test "$1" != "/usr/include"; then
++  if test "$1" != "$PHP_OS_SDKPATH/usr/include"; then
+     PHP_EXPAND_PATH($1, ai_p)
+     PHP_RUN_ONCE(INCLUDEPATH, $ai_p, [
+       if test "$2"; then
+diff --git a/configure.ac b/configure.ac
+index 36c6e5e3e2..71b1a16607 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -190,6 +190,14 @@ PHP_ARG_WITH([libdir],
+   [lib],
+   [no])
+
++dnl Support systems with system libraries/includes in e.g. /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk.
++PHP_ARG_WITH([os-sdkpath],
++  [for system SDK directory],
++  [AS_HELP_STRING([--with-os-sdkpath=NAME],
++    [Ignore system libraries and includes in NAME rather than /])],
++  [],
++  [no])
++
+ PHP_ARG_ENABLE([rpath],
+   [whether to enable runpaths],
+   [AS_HELP_STRING([--disable-rpath],

--- a/README.md
+++ b/README.md
@@ -31,17 +31,22 @@
 
 ## PHP Support
 
-|PHP Version|Formula|
-|--- |--- |
-PHP 5.6|`php@5.6`|
-PHP 7.0|`php@7.0`|
-PHP 7.1|`php@7.1`|
-PHP 7.2|`php@7.2`|
-PHP 7.3|`php@7.3`|
-PHP 7.4|`php@7.4`|
-PHP 8.0|`php@8.0`|
-PHP 8.1|`php` or `php@8.1`|
-PHP 8.2.0-dev|`php@8.2`|
+|PHP Version|Formula|Debug version|
+|--- |--- |--- |
+PHP 5.6|`php@5.6`|`php@5.6-debug`|
+PHP 7.0|`php@7.0`|`php@7.0-debug`|
+PHP 7.1|`php@7.1`|`php@7.1-debug`|
+PHP 7.2|`php@7.2`|`php@7.2-debug`|
+PHP 7.3|`php@7.3`|`php@7.3-debug`|
+PHP 7.4|`php@7.4`|`php@7.4-debug`|
+PHP 8.0|`php@8.0`|`php@8.0-debug`|
+PHP 8.1|`php` or `php@8.1`|`php@8.1-debug`|
+PHP 8.2.0-dev|`php@8.2`|`php@8.2-debug`|
+
+### Debug versions
+
+For each PHP version there is an extra formula with debug symbols enabled. This version can be used when building
+or debugging PHP extensions and are not recommended for production usage.
 
 ## OS Support
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ PHP 7.2|`php@7.2`|`php@7.2-debug`|
 PHP 7.3|`php@7.3`|`php@7.3-debug`|
 PHP 7.4|`php@7.4`|`php@7.4-debug`|
 PHP 8.0|`php@8.0`|`php@8.0-debug`|
-PHP 8.1|`php` or `php@8.1`|`php@8.1-debug`|
+PHP 8.1|`php` or `php@8.1`|`php-debug` or `php@8.1-debug`|
 PHP 8.2.0-dev|`php@8.2`|`php@8.2-debug`|
 
 ### Debug versions


### PR DESCRIPTION
---
name: 🎉 New Feature
about: Adds formulae to build PHP with debug symbols
labels: enhancement

---

## A Pull Request should be associated with a discussion.

Related discussion: #972 

### Description

This PR adds formulae to build PHP with debug symbols. Each file is a copy or the respective non-debug version with the following changes:
* Name changed to match filename
* Added `--enable-debug` switch to `configure` call
* Adapted `${version.major_minor}` or `php_version()` to include a `-debug` suffix - this is necessary to keep separate configurations and extensions

@shivammathur I believe the `fetch` function in `.github/scripts/edit.sh` may trip over these new version strings, but I'm not sure. I'm hoping the build will tell me what to change there, but I'd appreciate any pointer you could give me.
