### PR TITLE
Add `--enable-embed` config option for debug PHP versions.

### DIFF
--- a/Formula/php-debug.rb
+++ b/Formula/php-debug.rb
@@ -130,6 +130,7 @@ class PhpDebug < Formula
       --enable-calendar
       --enable-dba
       --enable-debug
+      --enable-embed
       --enable-exif
       --enable-ftp
       --enable-fpm

--- a/Formula/php@5.6-debug.rb
+++ b/Formula/php@5.6-debug.rb
@@ -133,6 +133,7 @@ class PhpAT56Debug < Formula
       --enable-calendar
       --enable-dba
       --enable-debug
+      --enable-embed
       --enable-exif
       --enable-ftp
       --enable-fpm

--- a/Formula/php@7.0-debug.rb
+++ b/Formula/php@7.0-debug.rb
@@ -134,6 +134,7 @@ class PhpAT70Debug < Formula
       --enable-calendar
       --enable-dba
       --enable-debug
+      --enable-embed
       --enable-exif
       --enable-ftp
       --enable-fpm

--- a/Formula/php@7.1-debug.rb
+++ b/Formula/php@7.1-debug.rb
@@ -127,6 +127,7 @@ class PhpAT71Debug < Formula
       --enable-calendar
       --enable-dba
       --enable-debug
+      --enable-embed
       --enable-exif
       --enable-ftp
       --enable-fpm

--- a/Formula/php@7.2-debug.rb
+++ b/Formula/php@7.2-debug.rb
@@ -129,6 +129,7 @@ class PhpAT72Debug < Formula
       --enable-calendar
       --enable-dba
       --enable-debug
+      --enable-embed
       --enable-exif
       --enable-ftp
       --enable-fpm

--- a/Formula/php@7.3-debug.rb
+++ b/Formula/php@7.3-debug.rb
@@ -126,6 +126,7 @@ class PhpAT73Debug < Formula
       --enable-calendar
       --enable-dba
       --enable-debug
+      --enable-embed
       --enable-exif
       --enable-ftp
       --enable-fpm

--- a/Formula/php@7.4-debug.rb
+++ b/Formula/php@7.4-debug.rb
@@ -133,6 +133,7 @@ class PhpAT74Debug < Formula
       --enable-calendar
       --enable-dba
       --enable-debug
+      --enable-embed
       --enable-exif
       --enable-ftp
       --enable-fpm

--- a/Formula/php@8.0-debug.rb
+++ b/Formula/php@8.0-debug.rb
@@ -140,6 +140,7 @@ class PhpAT80Debug < Formula
       --enable-calendar
       --enable-dba
       --enable-debug
+      --enable-embed
       --enable-exif
       --enable-ftp
       --enable-fpm

--- a/Formula/php@8.1-debug.rb
+++ b/Formula/php@8.1-debug.rb
@@ -122,6 +122,7 @@ class PhpAT81Debug < Formula
       --enable-calendar
       --enable-dba
       --enable-debug
+      --enable-embed
       --enable-exif
       --enable-ftp
       --enable-fpm

--- a/Formula/php@8.3-debug.rb
+++ b/Formula/php@8.3-debug.rb
@@ -123,6 +123,7 @@ class PhpAT83Debug < Formula
       --enable-calendar
       --enable-dba
       --enable-debug
+      --enable-embed
       --enable-exif
       --enable-ftp
       --enable-fpm

--- a/Formula/php@8.4-debug.rb
+++ b/Formula/php@8.4-debug.rb
@@ -123,6 +123,7 @@ class PhpAT84Debug < Formula
       --enable-calendar
       --enable-dba
       --enable-debug
+      --enable-embed
       --enable-exif
       --enable-ftp
       --enable-fpm


### PR DESCRIPTION
---
name: 🎉 New Feature
about: Add `--enable-embed` for PHP debug versions
labels: enhancement

---

### Description
We're using on our CI the [embed SAPI](https://github.com/php/php-src/tree/master/sapi/embed) of PHP to test some bindings with our extension.
I think it would be a nice addition to the debug bins

