### PR TITLE
feat: Set the PHP_BUILD_PROVIDER env variable for php@8.* 

### DIFF
--- a/Formula/php-debug-zts.rb
+++ b/Formula/php-debug-zts.rb
@@ -100,6 +100,9 @@ class PhpDebugZts < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in php -v output and phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php-debug.rb
+++ b/Formula/php-debug.rb
@@ -102,6 +102,9 @@ class PhpDebug < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in php -v output and phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php-zts.rb
+++ b/Formula/php-zts.rb
@@ -100,6 +100,9 @@ class PhpZts < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in php -v output and phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -100,6 +100,9 @@ class Php < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in php -v output and phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.0-debug-zts.rb
+++ b/Formula/php@8.0-debug-zts.rb
@@ -111,6 +111,9 @@ class PhpAT80DebugZts < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.0-debug.rb
+++ b/Formula/php@8.0-debug.rb
@@ -111,6 +111,9 @@ class PhpAT80Debug < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.0-zts.rb
+++ b/Formula/php@8.0-zts.rb
@@ -111,6 +111,9 @@ class PhpAT80Zts < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.0.rb
+++ b/Formula/php@8.0.rb
@@ -111,6 +111,9 @@ class PhpAT80 < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.1-debug-zts.rb
+++ b/Formula/php@8.1-debug-zts.rb
@@ -114,6 +114,9 @@ class PhpAT81DebugZts < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.1-debug.rb
+++ b/Formula/php@8.1-debug.rb
@@ -114,6 +114,9 @@ class PhpAT81Debug < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.1-zts.rb
+++ b/Formula/php@8.1-zts.rb
@@ -114,6 +114,9 @@ class PhpAT81Zts < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.1.rb
+++ b/Formula/php@8.1.rb
@@ -114,6 +114,9 @@ class PhpAT81 < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.2-debug-zts.rb
+++ b/Formula/php@8.2-debug-zts.rb
@@ -98,6 +98,9 @@ class PhpAT82DebugZts < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.2-debug.rb
+++ b/Formula/php@8.2-debug.rb
@@ -98,6 +98,9 @@ class PhpAT82Debug < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.2-zts.rb
+++ b/Formula/php@8.2-zts.rb
@@ -98,6 +98,9 @@ class PhpAT82Zts < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.2.rb
+++ b/Formula/php@8.2.rb
@@ -98,6 +98,9 @@ class PhpAT82 < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.3-debug-zts.rb
+++ b/Formula/php@8.3-debug-zts.rb
@@ -93,6 +93,9 @@ class PhpAT83DebugZts < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.3-debug.rb
+++ b/Formula/php@8.3-debug.rb
@@ -93,6 +93,9 @@ class PhpAT83Debug < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.3-zts.rb
+++ b/Formula/php@8.3-zts.rb
@@ -93,6 +93,9 @@ class PhpAT83Zts < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.3.rb
+++ b/Formula/php@8.3.rb
@@ -93,6 +93,9 @@ class PhpAT83 < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.5-debug-zts.rb
+++ b/Formula/php@8.5-debug-zts.rb
@@ -96,6 +96,9 @@ class PhpAT85DebugZts < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in php -v output and phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.5-debug.rb
+++ b/Formula/php@8.5-debug.rb
@@ -96,6 +96,9 @@ class PhpAT85Debug < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in php -v output and phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.5-zts.rb
+++ b/Formula/php@8.5-zts.rb
@@ -96,6 +96,9 @@ class PhpAT85Zts < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in php -v output and phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?

--- a/Formula/php@8.5.rb
+++ b/Formula/php@8.5.rb
@@ -96,6 +96,9 @@ class PhpAT85 < Formula
     # Prevent homebrew from hardcoding path to sed shim in phpize script
     ENV["lt_cv_path_SED"] = "sed"
 
+    # Identify build provider in php -v output and phpinfo()
+    ENV["PHP_BUILD_PROVIDER"] = "shivammathur/homebrew-php"
+
     # system pkg-config missing
     ENV["KERBEROS_CFLAGS"] = " "
     if OS.mac?


### PR DESCRIPTION
Available since PHP 8.0 this helps give attribution to the build providers and eases debugging and troubleshooting efforts for users and the php-src team.

`php -v` output and `phpinfo()` will include the variable. E.g.:

```
➜  Formula git:(add-php-build-provider) /opt/homebrew/opt/php@8.5/bin/php -v
PHP 8.5.0-dev (cli) (built: Jan 12 2025 19:42:59) (NTS)
Copyright (c) The PHP Group
Built by shivammathur/homebrew-php
Zend Engine v4.5.0-dev, Copyright (c) Zend Technologies
    with Zend OPcache v8.5.0-dev, Copyright (c), by Zend Technologies
```

I've chosen `shivammathur/homebrew-php` as the build provider here to include the tap name and a mention of homebrew, but have no specific idea on what you like, and I'm happy to go with whatever you like. 

This was also merged into homebrew-core and in the official docker images, linked for reference.

See: https://github.com/Homebrew/homebrew-core/pull/204084
See: https://github.com/docker-library/php/commit/5f736d03c48289f2ce210ff9af40b06e67a55c82#diff-7470d6e17f98284975fbf429241bd3056d7670399c3db6ade97d3edb40721370R114
See: https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502