### PR TITLE
build dynamic libphp (instead of static) on macOS

### DIFF
--- a/Formula/php-debug-zts.rb
+++ b/Formula/php-debug-zts.rb
@@ -215,15 +215,7 @@ class PhpDebugZts < Formula
     args << "--disable-cgi"
     args << "--disable-cli"
     args << "--disable-phpdbg"
-
-    if OS.mac?
-      args << "--disable-opcache-jit"
-      args << "--enable-embed=static"
-      args << "--enable-shared=no"
-      args << "--enable-static"
-    else
-      args << "--enable-embed"
-    end
+    args << "--enable-embed"
 
     system "./configure", *args
     system "make"

--- a/Formula/php-zts.rb
+++ b/Formula/php-zts.rb
@@ -214,15 +214,7 @@ class PhpZts < Formula
     args << "--disable-cgi"
     args << "--disable-cli"
     args << "--disable-phpdbg"
-
-    if OS.mac?
-      args << "--disable-opcache-jit"
-      args << "--enable-embed=static"
-      args << "--enable-shared=no"
-      args << "--enable-static"
-    else
-      args << "--enable-embed"
-    end
+    args << "--enable-embed"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@8.3-debug-zts.rb
+++ b/Formula/php@8.3-debug-zts.rb
@@ -209,15 +209,7 @@ class PhpAT83DebugZts < Formula
     args << "--disable-cgi"
     args << "--disable-cli"
     args << "--disable-phpdbg"
-
-    if OS.mac?
-      args << "--disable-opcache-jit"
-      args << "--enable-embed=static"
-      args << "--enable-shared=no"
-      args << "--enable-static"
-    else
-      args << "--enable-embed"
-    end
+    args << "--enable-embed"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@8.3-zts.rb
+++ b/Formula/php@8.3-zts.rb
@@ -208,15 +208,7 @@ class PhpAT83Zts < Formula
     args << "--disable-cgi"
     args << "--disable-cli"
     args << "--disable-phpdbg"
-
-    if OS.mac?
-      args << "--disable-opcache-jit"
-      args << "--enable-embed=static"
-      args << "--enable-shared=no"
-      args << "--enable-static"
-    else
-      args << "--enable-embed"
-    end
+    args << "--enable-embed"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@8.5-debug-zts.rb
+++ b/Formula/php@8.5-debug-zts.rb
@@ -213,15 +213,7 @@ class PhpAT85DebugZts < Formula
     args << "--disable-cgi"
     args << "--disable-cli"
     args << "--disable-phpdbg"
-
-    if OS.mac?
-      args << "--disable-opcache-jit"
-      args << "--enable-embed=static"
-      args << "--enable-shared=no"
-      args << "--enable-static"
-    else
-      args << "--enable-embed"
-    end
+    args << "--enable-embed"
 
     system "./configure", *args
     system "make"

--- a/Formula/php@8.5-zts.rb
+++ b/Formula/php@8.5-zts.rb
@@ -212,15 +212,7 @@ class PhpAT85Zts < Formula
     args << "--disable-cgi"
     args << "--disable-cli"
     args << "--disable-phpdbg"
-
-    if OS.mac?
-      args << "--disable-opcache-jit"
-      args << "--enable-embed=static"
-      args << "--enable-shared=no"
-      args << "--enable-static"
-    else
-      args << "--enable-embed"
-    end
+    args << "--enable-embed"
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
---
name: ⚙ Improvement
about: want to improve something
labels: enhancement

---

### Description

Now that dynamic libphp is supported on macOS (https://github.com/dunglas/frankenphp/pull/1515), let's build it instead of the static version.
Also related: https://github.com/dunglas/frankenphp/pull/1515
