### PR TITLE
php@8.5-debug-zts: build dynamic libphp (instead of static) on macOS

### DIFF
--- a/Formula/php@8.5-debug-zts.rb
+++ b/Formula/php@8.5-debug-zts.rb
@@ -5,7 +5,7 @@ class PhpAT85DebugZts < Formula
   version "8.5.0"
   sha256 "d562fd57680470a05e43d2f39b3e97daa24f34f55eec0e415be3be8dbe02cadc"
   license "PHP-3.01"
-  revision 3
+  revision 4
 
   bottle do
     root_url "https://ghcr.io/v2/shivammathur/php"
@@ -213,15 +213,7 @@ class PhpAT85DebugZts < Formula
     args << "--disable-cgi"
     args << "--disable-cli"
     args << "--disable-phpdbg"
-
-    if OS.mac?
-      args << "--disable-opcache-jit"
-      args << "--enable-embed=static"
-      args << "--enable-shared=no"
-      args << "--enable-static"
-    else
-      args << "--enable-embed"
-    end
+    args << "--enable-embed"
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
php@8.5-debug-zts: build dynamic libphp (instead of static) on macOS