### PR TITLE
php@7.2-debug-zts: use gcc on macOS

### DIFF
--- a/Formula/php@7.2-debug-zts.rb
+++ b/Formula/php@7.2-debug-zts.rb
@@ -64,8 +64,15 @@ class PhpAT72DebugZts < Formula
   uses_from_macos "zlib"
 
   on_macos do
+    depends_on "gcc"
+
     # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/issues/10680
     patch :DATA
+  end
+
+  fails_with :clang do
+    cause "Performs worse due to lack of general global register variables"
   end
 
   patch do
@@ -73,7 +80,14 @@ class PhpAT72DebugZts < Formula
     sha256 "938f26a35673938935d1145191ded7006077e75aaf0de0122fefd630eecb63ae"
   end
 
+  # https://github.com/Homebrew/homebrew-core/issues/235820
+  # https://clang.llvm.org/docs/UsersManual.html#gcc-extensions-not-implemented-yet
+
   def install
+    # GCC -Os performs worse than -O1 and significantly worse than -O2/-O3.
+    # We lack a DSL to enable -O2 so just use -O3 which is similar.
+    ENV.O3 if OS.mac?
+
     # Work around configure issues with Xcode 12
     # See https://bugs.php.net/bug.php?id=80171
     ENV.append "CFLAGS", "-Wno-implicit-function-declaration"


### PR DESCRIPTION
php@7.2-debug-zts: use gcc on macOS