### PR TITLE
php@7.4: use gcc on macOS

### DIFF
--- a/Formula/php@7.4.rb
+++ b/Formula/php@7.4.rb
@@ -63,15 +63,36 @@ class PhpAT74 < Formula
   uses_from_macos "zlib"
 
   on_macos do
+    depends_on "gcc"
+
     # PHP build system incorrectly links system libraries
+    # see https://github.com/php/php-src/issues/10680
     patch :DATA
   end
 
+  # https://github.com/Homebrew/homebrew-core/issues/235820
+  # https://clang.llvm.org/docs/UsersManual.html#gcc-extensions-not-implemented-yet
+  fails_with :clang do
+    cause "Performs worse due to lack of general global register variables"
+  end
+
   def install
+    # GCC -Os performs worse than -O1 and significantly worse than -O2/-O3.
+    # We lack a DSL to enable -O2 so just use -O3 which is similar.
+    ENV.O3 if OS.mac?
+
     # Work around for building with Xcode 15.3
     if DevelopmentTools.clang_build_version >= 1500
       ENV.append "CFLAGS", "-Wno-incompatible-function-pointer-types"
       ENV.append "LDFLAGS", "-lresolv"
+    end
+
+    if OS.mac? && ENV.compiler.to_s.start_with?("gcc")
+      ENV.append "CFLAGS", "-Wno-incompatible-pointer-types"
+      ENV.append "CPPFLAGS", "-DL_ctermid=1024"
+      inreplace "ext/gd/gd.c", "func_p)()", "func_p)(...)"
+      inreplace "ext/gd/gd_ctx.c", "func_p)()", "func_p)(...)"
+      inreplace "ext/standard/scanf.c", "zend_long (*fn)()", "zend_long (*fn)(...)"
     end
 
     # Work around to support `icu4c` 75, which needs C++17.


### PR DESCRIPTION
php@7.4: use gcc on macOS