### PR TITLE
php: make cURL CURLOPT_VERBOSE a long (0L)

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -86,6 +86,9 @@ class Php < Formula
     # buildconf required due to system library linking bug patch
     system "./buildconf", "--force"
 
+    # cURL needs the value to be long,
+    inreplace "ext/curl/interface.c", /CURLOPT_VERBOSE,\s+0/, "CURLOPT_VERBOSE, 0L"
+
     inreplace "configure" do |s|
       s.gsub! "$APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes' >/dev/null 2>&1",
               "false"


### PR DESCRIPTION
php: make cURL CURLOPT_VERBOSE a long (0L)