### PR TITLE
php-debug: make cURL CURLOPT_VERBOSE a long (0L)

### DIFF
--- a/Formula/php-debug.rb
+++ b/Formula/php-debug.rb
@@ -88,6 +88,9 @@ class PhpDebug < Formula
     # buildconf required due to system library linking bug patch
     system "./buildconf", "--force"
 
+    # cURL needs the value to be long,
+    inreplace "ext/curl/interface.c", /CURLOPT_VERBOSE,\s+0/, "CURLOPT_VERBOSE, 0L"
+
     inreplace "configure" do |s|
       s.gsub! "$APXS_HTTPD -V 2>/dev/null | grep 'threaded:.*yes' >/dev/null 2>&1",
               "false"


### PR DESCRIPTION
php-debug: make cURL CURLOPT_VERBOSE a long (0L)