### PR TITLE
workflows: remove `test-bot` Action input

### DIFF
--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -14,8 +14,6 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main
-        with:
-          test-bot: false
 
       - name: Run automerge
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: true
 
       - run: brew test-bot --only-tap-syntax
 
@@ -125,7 +124,6 @@ jobs:
         with:
           core: false
           cask: false
-          test-bot: false
 
       - name: Patch formula
         env:

--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -131,7 +131,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Download bottles from GitHub Actions
         uses: actions/download-artifact@v4

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -117,7 +117,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Download bottles from GitHub Actions
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Configure Git user
         id: git-user-config


### PR DESCRIPTION
`test-bot` has been merged into Homebrew/brew, so this is no longer necessary and outputs a warning in CI.

---

- https://github.com/Homebrew/brew/pull/20762