### PR TITLE
php@8.6-zts: revision bump (net-snmp 5.9.5.2)

### DIFF
--- a/Formula/php@8.6-zts.rb
+++ b/Formula/php@8.6-zts.rb
@@ -28,6 +28,7 @@ class PhpAT86Zts < Formula
     "TCL",                   # 7
     "Zlib",                  # 8
   ]
+  revision 1
 
   bottle do
     root_url "https://ghcr.io/v2/shivammathur/php"


### PR DESCRIPTION
php@8.6-zts: revision bump (net-snmp 5.9.5.2)